### PR TITLE
Choices/Main: uses `overflow-y-auto` instead.

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -140,7 +140,7 @@ class Choices extends Component
                         
                         <!-- OPTIONS -->
                         @if(count($options) || $noResultText)
-                            <div class="absolute w-full bg-base-100 mt-2 z-10 pb-0.5 border border-base-300 shadow-xl cursor-pointer rounded-lg overflow-y-scroll max-h-64">
+                            <div class="absolute w-full bg-base-100 mt-2 z-10 pb-0.5 border border-base-300 shadow-xl cursor-pointer rounded-lg overflow-y-auto max-h-64">
                                 @foreach($options as $option)
                                     <div        
                                         wire:key="option-{{ data_get($option, $optionValue) }}"

--- a/src/View/Components/Main.php
+++ b/src/View/Components/Main.php
@@ -52,7 +52,7 @@ class Main extends Component
 
                                         {{ 
                                             $sidebar->attributes->class([
-                                                "hidden lg:block h-screen transition-all duration-100 ease-out overflow-y-scroll overflow-x-hidden",
+                                                "hidden lg:block h-screen transition-all duration-100 ease-out overflow-y-auto overflow-x-hidden",
                                                 "pb-24" => $withNav,
                                                 "w-[70px] [&>*_summary::after]:hidden [&_.mary-hideable]:hidden [&_.display-when-collapsed]:block [&_.hidden-when-collapsed]:hidden" => cache('mary-sidebar-collapsed') == 'true',
                                                 "w-[270px] [&>*_summary::after]:block [&_.mary-hideable]:block [&_.hidden-when-collapsed]:block [&_.display-when-collapsed]:hidden" => cache('mary-sidebar-collapsed') != 'true'


### PR DESCRIPTION
Fixes #28