### PR TITLE
Update MenuItem.php

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -31,7 +31,7 @@ class MenuItem extends Component
         $link = url($this->link ?? '');
         $route = url(Route::current()->uri());
 
-        return Str::startsWith($route, $link);
+        return $link == $route;
     }
 
     public function render(): View|Closure|string


### PR DESCRIPTION
hi @robsontenorio 

Changed the URL judgment of MenuItem's activate-by-route attribute to exact match.

In the current implementation, `Str::startsWith` is used, so `/tags` and `/tags/create` are judged to be the same, and the  `background-color` of  `activate-by-route` is set for both. Applicable.

This fix can successfully correct this behavior.
I would like you to merge it.