### PR TITLE
fix: added pt-0 to select label

### DIFF
--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -36,7 +36,7 @@ class Select extends Component
             <div wire:key="{{ $uuid }}">                
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label class="label label-text font-semibold">{{ $label }}</label>
+                    <label class="pt-0 label label-text font-semibold">{{ $label }}</label>
                 @endif
                 
                 <div class="relative">                 


### PR DESCRIPTION
Edited: `src/View/Components/Select.php`

This PR aims to improve the UI consistency by adding pt-0 to the select input label. The modification aligns the select box with text input elements.

Added pt-0 for consistency, making sure that the select input labels are aligned with text input labels across components.

Without `pt-0`:

<img width="508" alt="image" src="https://github.com/robsontenorio/mary/assets/1971953/57240949-b15d-468d-91f6-d219b06e1024">

With the fix:

<img width="444" alt="image" src="https://github.com/robsontenorio/mary/assets/1971953/56481e06-8924-461c-bfdb-4aff84049a5b">

