### PR TITLE
Table: add `no-headers` attribute.

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -15,6 +15,7 @@ class Table extends Component
         public array $headers,
         public ArrayAccess|array $rows,
         public ?bool $striped = false,
+        public ?bool $noHeaders = false,
 
         // Slots
         public mixed $actions = null,
@@ -36,7 +37,7 @@ class Table extends Component
                         }}
                     >
                         <!-- HEADERS -->
-                        <thead class="text-black">
+                        <thead @class(["text-black dark:text-gray-500", "hidden" => $noHeaders])>
                             <tr>
                                 @foreach($headers as $header)
                                      @php


### PR DESCRIPTION
<img width="897" alt="image" src="https://github.com/robsontenorio/mary/assets/118955/88aaba41-78fa-4333-82aa-a44275cffa10">
