### PR TITLE
CSS: improve some components

### DIFF
--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -16,34 +16,33 @@ class Dropdown extends Component
         //Slots
         public mixed $trigger = null
     ) {
-
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-            <details 
-                class="dropdown @if($right) dropdown-end @endif" 
-                x-data="{open: false}" 
-                @click.outside="open = false" 
+            <details
+                class="dropdown @if($right) dropdown-end @endif"
+                x-data="{open: false}"
+                @click.outside="open = false"
                 :open="open"
-            >                
-                <!-- CUSTOM TRIGGER -->                        
+            >
+                <!-- CUSTOM TRIGGER -->
                 @if($trigger)
-                    <summary @click.prevent="open = !open">
-                        {{ $trigger }}                                               
+                    <summary @click.prevent="open = !open" class="list-none">
+                        {{ $trigger }}
                     </summary>
                 @else
                     <!-- DEFAULT TRIGGER -->
                     <summary @click.prevent="open = !open" {{ $attributes->class(["btn normal-case"]) }}>
                         {{ $label }}
-                        <x-icon :name="$icon" />                        
-                    </summary>                                                        
-                @endif                        
+                        <x-icon :name="$icon" />
+                    </summary>
+                @endif
                 <ul @click="open = false" class="dropdown-content p-2 shadow menu z-[1] bg-base-100 dark:bg-base-200 rounded-box whitespace-nowrap">
                     {{ $slot }}
                 </ul>
-            </details>             
+            </details>
         HTML;
     }
 }

--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -72,7 +72,13 @@ class Header extends Component
 
                         @if($progressIndicator)
                             <div class="h-0.5 -mt-9 mb-9">
-                                <progress wire:loading @if($progressTarget()) wire:target="{{ $progressTarget() }}"  @endif class="progress w-full h-0.5"></progress>
+                                <progress
+                                    class="progress progress-primary w-full h-0.5 dark:h-1"
+                                    wire:loading
+
+                                    @if($progressTarget())
+                                        wire:target="{{ $progressTarget() }}"
+                                     @endif></progress>
                             </div>
                         @endif
                     @endif

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -49,7 +49,7 @@ class Input extends Component
             <div>
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label class="pt-0 label label-text font-semibold">{{ $label }}</label>
+                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">{{ $label }}</label>
                 @endif
 
                 <!-- PREFIX/SUFFIX/PREPEND/APPEND CONTAINER -->
@@ -59,7 +59,7 @@ class Input extends Component
 
                 <!-- PREFIX / PREPEND -->
                 @if($prefix || $prepend)
-                    <div class="rounded-l-lg flex items-center bg-base-200 @if($prefix) border border-base-300 px-4 @endif">
+                    <div class="rounded-l-lg flex items-center bg-base-200 @if($prefix) border border-primary border-r-0 px-4 @endif">
                         {{ $prepend ?? $prefix }}
                     </div>
                 @endif
@@ -103,17 +103,17 @@ class Input extends Component
 
                     <!-- ICON  -->
                     @if($icon)
-                        <x-icon :name="$icon" class="absolute top-1/2 -translate-y-1/2 left-3 text-gray-400 " />
+                        <x-icon :name="$icon" class="absolute top-1/2 -translate-y-1/2 left-3 text-gray-400 pointer-events-none" />
                     @endif
 
                     <!-- RIGHT ICON  -->
                     @if($iconRight)
-                        <x-icon :name="$iconRight" class="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 " />
+                        <x-icon :name="$iconRight" class="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 pointer-events-none" />
                     @endif
 
                     <!-- INLINE LABEL -->
                     @if($label && $inline)
-                        <label for="{{ $uuid }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] bg-white rounded dark:bg-gray-900 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                        <label for="{{ $uuid }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
                             {{ $label }}
                         </label>
                     @endif
@@ -127,7 +127,7 @@ class Input extends Component
 
                 <!-- SUFFIX/APPEND -->
                 @if($suffix || $append)
-                    <div class="rounded-r-lg flex items-center bg-base-200 @if($suffix) border border-base-300 px-4 @endif">
+                    <div class="rounded-r-lg flex items-center bg-base-200 @if($suffix) border border-primary border-l-0 px-4 @endif">
                         {{ $append ?? $suffix }}
                     </div>
                 @endif

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -58,7 +58,7 @@ class MenuItem extends Component
                             <x-icon :name="$icon" />
                         @endif
 
-                        <span class="mary-hideable">
+                        <span class="mary-hideable whitespace-nowrap">
                             @if($title)
                                 {{ $title }}
 

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -33,25 +33,26 @@ class Select extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-            <div wire:key="{{ $uuid }}">                
+            <div wire:key="{{ $uuid }}">
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label class="pt-0 label label-text font-semibold">{{ $label }}</label>
+                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">{{ $label }}</label>
                 @endif
-                
-                <div class="relative">                 
-                    <select 
-                        {{ $attributes->whereDoesntStartWith('class') }} 
+
+                <div class="relative">
+                    <select
+                        id="{{ $uuid }}"
+                        {{ $attributes->whereDoesntStartWith('class') }}
                         {{ $attributes->class([
-                                    'select select-primary w-full font-normal', 
-                                    'pl-10' => ($icon), 
+                                    'select select-primary w-full font-normal',
+                                    'pl-10' => ($icon),
                                     'h-14' => ($inline),
                                     'pt-3' => ($inline && $label),
                                     'border border-dashed' => $attributes->has('readonly'),
                                     'select-error' => $errors->has($modelName())
-                                ]) 
+                                ])
                         }}
-                        
+
                     >
                         @if($placeholder)
                             <option>{{ $placeholder }}</option>
@@ -64,19 +65,19 @@ class Select extends Component
 
                     <!-- ICON -->
                     @if($icon)
-                        <x-icon :name="$icon" class="absolute top-1/2 -translate-y-1/2 left-3 text-gray-400" />                     
+                        <x-icon :name="$icon" class="absolute pointer-events-none top-1/2 -translate-y-1/2 left-3 text-gray-400" />
                     @endif
 
                     <!-- RIGHT ICON  -->
                     @if($iconRight)
-                        <x-icon :name="$iconRight" class="absolute top-1/2 right-8 -translate-y-1/2 text-gray-400 " />
+                        <x-icon :name="$iconRight" class="absolute pointer-events-none top-1/2 right-8 -translate-y-1/2 text-gray-400 " />
                     @endif
 
                     <!-- INLINE LABEL -->
-                    @if($label && $inline)                        
-                        <label class="absolute text-gray-500 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] bg-white rounded dark:bg-gray-900 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
-                            {{ $label }}                                
-                        </label>                                                 
+                    @if($label && $inline)
+                        <label for="{{ $uuid }}" class="absolute pointer-events-none text-gray-500 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                            {{ $label }}
+                        </label>
                     @endif
                 </div>
 


### PR DESCRIPTION
**Header**: primary color for progress indicator , default color for dark.
**Input**: primary color for border at prefix/suffix 
**Dropbox**: hide caret summary icon
**Select**: better inline label background for dark,  "clickable" inline label, "clickable" icons.
**Input**: better inline label background for dark, bind label to field input,  "clickable" icons.