### PR TITLE
Choices: fix option value is not defined

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -158,7 +158,7 @@ class Choices extends Component
                                         "
                                         :class="
                                             @if($single)
-                                                selection == {{ data_get($option, $optionValue) }} && 'bg-primary/5'
+                                                selection == '{{ data_get($option, $optionValue) }}' && 'bg-primary/5'
                                             @else
                                                 selection.includes({{ data_get($option, $optionValue) }}) && 'bg-primary/5'
                                             @endif


### PR DESCRIPTION
if value is a string (e.g. SQUARE), it will present 
```
selection  == SQUARE
```

which is throw an exception
> Apine Expression Error: SQUARE is not defined
> Expression: "selection == SQUARE && 'bg-primary/5'"