### PR TITLE
Include Close on Outside Click for Modal Component (Enabled by Default)

### DIFF
--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -13,7 +13,7 @@ class Modal extends Component
         public ?string $title = null,
         public ?string $subtitle = null,
         public ?bool $separator = false,
-        public ?bool $closeOutside = true,
+        public ?bool $persistent = false,
 
         // Slots
         public ?string $actions = null
@@ -33,7 +33,9 @@ class Modal extends Component
                         x-data="{open: @entangle($attributes->wire('model')).live }"                         
                         :class="{'modal-open !animate-none': open}"
                         :open="open"
-                        @keydown.escape.window = "$wire.{{ $attributes->wire('model')->value() }} = false"
+                        @if(!$persistent)
+                            @keydown.escape.window = "$wire.{{ $attributes->wire('model')->value() }} = false"
+                        @endif
                     @endif
                 >
                     <div class="modal-box">
@@ -54,7 +56,7 @@ class Modal extends Component
                         </div>
                     </div>
 
-                    @if($closeOutside)
+                    @if(!$persistent)
                     <form class="modal-backdrop" method="dialog">
                         <span x-on:click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
                     </form>

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -24,13 +24,13 @@ class Modal extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <dialog 
+                <dialog
                     {{ $attributes->except('wire:model')->class(["modal"]) }}
-                    
+
                     @if($id)
                         id="{{ $id }}"
                     @else
-                        x-data="{open: @entangle($attributes->wire('model')).live }"                         
+                        x-data="{open: @entangle($attributes->wire('model')).live }"
                         :class="{'modal-open !animate-none': open}"
                         :open="open"
                         @if(!$persistent)
@@ -47,8 +47,8 @@ class Modal extends Component
                             {{ $slot }}
                         </p>
 
-                        @if($separator) 
-                            <hr class="mt-5" /> 
+                        @if($separator)
+                            <hr class="mt-5" />
                         @endif
 
                         <div class="modal-action">
@@ -57,9 +57,12 @@ class Modal extends Component
                     </div>
 
                     @if(!$persistent)
-                    <form class="modal-backdrop" method="dialog">
-                        <span x-on:click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
-                    </form>
+                        <form class="modal-backdrop" method="dialog">
+                            <button>invisible, just to allow close on click outside</button>
+                            @if(!$id)
+                                <span @click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
+                            @endif
+                        </form>
                     @endif
                 </dialog>
                 HTML;

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -13,6 +13,7 @@ class Modal extends Component
         public ?string $title = null,
         public ?string $subtitle = null,
         public ?bool $separator = false,
+        public ?bool $closeOutside = true,
 
         // Slots
         public ?string $actions = null
@@ -52,6 +53,12 @@ class Modal extends Component
                             {{ $actions }}
                         </div>
                     </div>
+
+                    @if($closeOutside)
+                    <form class="modal-backdrop" method="dialog">
+                        <span x-on:click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
+                    </form>
+                    @endif
                 </dialog>
                 HTML;
     }


### PR DESCRIPTION
**Description:**

In this PR, we have made significant changes to the Modal component. The modal is now designed to close by default when a user clicks outside or ESC key.

**New Feature:**

- We have introduced a new `persistent` prop. By default, the modal can be closed by clicking outside or pressing the ESC key. If you want to prevent this default closure behavior, you can use the `persistent` prop.

**Usage Example:**

```blade
<x-modal wire:model="myModal" persistent>
```

**Note:** _The author is welcome to make further adjustments or improvements to this code as needed. Feel free to modify the code to better._