### PR TITLE
Fix: component prefix for icons.

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -65,7 +65,7 @@ class MaryServiceProvider extends ServiceProvider
         // Just rename <x-icon> provided by BladeUI Icons to <x-svg> to not collide with ours
         Blade::component('BladeUI\Icons\Components\Icon', 'svg');
 
-        // Also register as <x-icon> if there is a prefix for Mary components
+        // Also register as <x-icon> even if there is a prefix for Mary components
         Blade::component('icon', Icon::class);
 
         $prefix = config('mary.prefix');

--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -65,6 +65,9 @@ class MaryServiceProvider extends ServiceProvider
         // Just rename <x-icon> provided by BladeUI Icons to <x-svg> to not collide with ours
         Blade::component('BladeUI\Icons\Components\Icon', 'svg');
 
+        // For now, we won't use prefix for icons
+        Blade::component('icon', Icon::class);
+
         $prefix = config('mary.prefix');
 
         // Blade
@@ -76,7 +79,6 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'chart', Chart::class);
         Blade::component($prefix . 'checkbox', Checkbox::class);
         Blade::component($prefix . 'choices', Choices::class);
-        Blade::component($prefix . 'choices2', Choices2::class);
         Blade::component($prefix . 'datepicker', DatePicker::class);
         Blade::component($prefix . 'datetime', DateTime::class);
         Blade::component($prefix . 'diff', Diff::class);
@@ -86,7 +88,6 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'form', Form::class);
         Blade::component($prefix . 'header', Header::class);
         Blade::component($prefix . 'input', Input::class);
-        Blade::component($prefix . 'icon', Icon::class);
         Blade::component($prefix . 'list-item', ListItem::class);
         Blade::component($prefix . 'modal', Modal::class);
         Blade::component($prefix . 'menu', Menu::class);

--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -65,7 +65,7 @@ class MaryServiceProvider extends ServiceProvider
         // Just rename <x-icon> provided by BladeUI Icons to <x-svg> to not collide with ours
         Blade::component('BladeUI\Icons\Components\Icon', 'svg');
 
-        // For now, we won't use prefix for icons
+        // Also register as <x-icon> if there is a prefix for Mary components
         Blade::component('icon', Icon::class);
 
         $prefix = config('mary.prefix');
@@ -87,6 +87,7 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'file', File::class);
         Blade::component($prefix . 'form', Form::class);
         Blade::component($prefix . 'header', Header::class);
+        Blade::component($prefix . 'icon', Icon::class);
         Blade::component($prefix . 'input', Input::class);
         Blade::component($prefix . 'list-item', ListItem::class);
         Blade::component($prefix . 'modal', Modal::class);


### PR DESCRIPTION
Fixes #117 

Also register as <x-icon> if there is a prefix for Mary components.

