### PR TITLE
ListItem: omit avatar if not used

### DIFF
--- a/src/View/Components/ListItem.php
+++ b/src/View/Components/ListItem.php
@@ -38,7 +38,7 @@ class ListItem extends Component
                     }}
                 >
 
-                    @if($link)
+                    @if($link && data_get($item, $avatar) || !is_string($avatar))
                         <div>
                             <a href="{{ $link }}" wire:navigate>
                     @endif
@@ -61,7 +61,7 @@ class ListItem extends Component
                     @endif
 
 
-                    @if($link)
+                    @if($link && data_get($item, $avatar) || !is_string($avatar))
                             </a>
                         </div>
                     @endif


### PR DESCRIPTION
- Avoid to render avatar div, if explicitly not used, for better spacing.