### PR TITLE
Tags: New component for managing multiple tags

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -38,6 +38,7 @@ use Mary\View\Components\Stat;
 use Mary\View\Components\Tab;
 use Mary\View\Components\Table;
 use Mary\View\Components\Tabs;
+use Mary\View\Components\Tags;
 use Mary\View\Components\Textarea;
 use Mary\View\Components\TimelineItem;
 use Mary\View\Components\Toast;
@@ -105,6 +106,7 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'table', Table::class);
         Blade::component($prefix . 'tab', Tab::class);
         Blade::component($prefix . 'tabs', Tabs::class);
+        Blade::component($prefix . 'tags', Tags::class);
         Blade::component($prefix . 'textarea', Textarea::class);
         Blade::component($prefix . 'timeline-item', TimelineItem::class);
         Blade::component($prefix . 'toast', Toast::class);

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -39,15 +39,15 @@ class Modal extends Component
                     @endif
                 >
                     <div class="modal-box">
-                        @if($title)
-                            <x-header :title="$title" :subtitle="$subtitle" size="text-2xl" :separator="$separator" class="mb-5" />
+                        @if ($title)
+                            <x-header :separator="$separator" :subtitle="$subtitle" :title="$title" class="mb-5" size="text-2xl" />
                         @endif
 
                         <p class="">
                             {{ $slot }}
                         </p>
 
-                        @if($separator)
+                        @if ($separator)
                             <hr class="mt-5" />
                         @endif
 
@@ -56,15 +56,16 @@ class Modal extends Component
                         </div>
                     </div>
 
-                    @if(!$persistent)
+                    @if (!$persistent)
                         <form class="modal-backdrop" method="dialog">
-                            <button>invisible, just to allow close on click outside</button>
-                            @if(!$id)
-                                <span @click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
+                            @if ($id)
+                                <button type="submit">close</button>
+                            @else
+                                <button @click="$wire.{{ $attributes->wire('model')->value() }} = false" type="button">close</button>
                             @endif
                         </form>
                     @endif
                 </dialog>
-                HTML;
+            HTML;
     }
 }

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -13,7 +13,7 @@ class Modal extends Component
         public ?string $title = null,
         public ?string $subtitle = null,
         public ?bool $separator = false,
-        public ?bool $closeOutside = true,
+        public ?bool $persistent = false,
 
         // Slots
         public ?string $actions = null
@@ -33,7 +33,9 @@ class Modal extends Component
                         x-data="{open: @entangle($attributes->wire('model')).live }"                         
                         :class="{'modal-open !animate-none': open}"
                         :open="open"
-                        @keydown.escape.window = "$wire.{{ $attributes->wire('model')->value() }} = false"
+                        @if(!$persistent)
+                            @keydown.escape.window = "$wire.{{ $attributes->wire('model')->value() }} = false"
+                        @endif
                     @endif
                 >
                     <div class="modal-box">
@@ -54,7 +56,7 @@ class Modal extends Component
                         </div>
                     </div>
 
-                    @if($closeOutside)
+                    @if(!$persistent)
                     <form class="modal-backdrop" method="dialog">
                         <span x-on:click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
                     </form>

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -24,13 +24,13 @@ class Modal extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <dialog 
+                <dialog
                     {{ $attributes->except('wire:model')->class(["modal"]) }}
-                    
+
                     @if($id)
                         id="{{ $id }}"
                     @else
-                        x-data="{open: @entangle($attributes->wire('model')).live }"                         
+                        x-data="{open: @entangle($attributes->wire('model')).live }"
                         :class="{'modal-open !animate-none': open}"
                         :open="open"
                         @if(!$persistent)
@@ -47,8 +47,8 @@ class Modal extends Component
                             {{ $slot }}
                         </p>
 
-                        @if($separator) 
-                            <hr class="mt-5" /> 
+                        @if($separator)
+                            <hr class="mt-5" />
                         @endif
 
                         <div class="modal-action">
@@ -57,9 +57,12 @@ class Modal extends Component
                     </div>
 
                     @if(!$persistent)
-                    <form class="modal-backdrop" method="dialog">
-                        <span x-on:click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
-                    </form>
+                        <form class="modal-backdrop" method="dialog">
+                            <button>invisible, just to allow close on click outside</button>
+                            @if(!$id)
+                                <span @click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
+                            @endif
+                        </form>
                     @endif
                 </dialog>
                 HTML;

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -13,6 +13,7 @@ class Modal extends Component
         public ?string $title = null,
         public ?string $subtitle = null,
         public ?bool $separator = false,
+        public ?bool $closeOutside = true,
 
         // Slots
         public ?string $actions = null
@@ -52,6 +53,12 @@ class Modal extends Component
                             {{ $actions }}
                         </div>
                     </div>
+
+                    @if($closeOutside)
+                    <form class="modal-backdrop" method="dialog">
+                        <span x-on:click="$wire.{{ $attributes->wire('model')->value() }} = false">close</span>
+                    </form>
+                    @endif
                 </dialog>
                 HTML;
     }

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Mary\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Tags extends Component
+{
+    public string $uuid;
+
+    public function __construct(
+        public ?string $label = null,
+        public ?string $icon = null,
+        public ?string $iconRight = null,
+        public ?string $hint = null,
+        public ?string $prefix = null,
+        public ?string $suffix = null,
+        public ?bool $inline = false,
+
+        // Slots
+        public mixed $prepend = null,
+        public mixed $append = null
+    ) {
+        $this->uuid = md5(serialize($this));
+    }
+
+    public function modelName(): ?string
+    {
+        return $this->attributes->whereStartsWith('wire:model')->first();
+    }
+
+    public function render(): View|Closure|string
+    {
+        return <<<'HTML'
+            <div @tags-update="console.log('tags updated', $event.detail.tags)" @click.away="clearSearch()" @keydown.escape="clearSearch()"
+                x-data="{
+                    tags: @entangle($attributes->wire('model')),
+                    myInput: '',
+                    open: false,
+
+                    addTag(tag) {
+                        tag = tag.trim()
+                        if (tag != '' && !this.hasTag(tag)) {
+                            this.tags.push(tag)
+                        }
+                        this.clearSearch()
+                        this.fireTagsUpdateEvent()
+                    },
+                    fireTagsUpdateEvent() {
+                        this.$el.dispatchEvent(new CustomEvent('tags-update', {
+                            detail: {
+                                tags: this.tags
+                            },
+                            bubbles: true,
+                        }));
+                    },
+                    hasTag(tag) {
+                        var tag = this.tags.find(e => {
+                            return e.toLowerCase() === tag.toLowerCase()
+                        })
+                        return tag != undefined
+                    },
+                    removeTag(index) {
+                        this.tags.splice(index, 1)
+                        this.fireTagsUpdateEvent()
+                    },
+                    search(q) {
+                        if (q.includes(',')) {
+                            q.split(',').forEach(function(val) {
+                                this.addTag(val)
+                            }, this)
+                        }
+                        this.toggleSearch()
+                    },
+                    clearSearch() {
+                        this.myInput = ''
+                        this.toggleSearch()
+                    },
+                    toggleSearch() {
+                        this.open = this.myInput != ''
+                    }
+                }">
+                
+                <!-- STANDARD LABEL -->
+                @if($label && !$inline)
+                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">{{ $label }}</label>
+                @endif
+
+                <!-- PREFIX/SUFFIX/PREPEND/APPEND CONTAINER -->
+                @if($prefix || $suffix || $prepend || $append)
+                    <div class="flex">
+                @endif
+
+                <!-- PREFIX / PREPEND -->
+                @if($prefix || $prepend)
+                    <div class="rounded-l-lg flex items-center bg-base-200 @if($prefix) border border-primary border-r-0 px-4 @endif">
+                        {{ $prepend ?? $prefix }}
+                    </div>
+                @endif
+                
+                <div class="flex-1 relative">
+                    <!-- INPUT -->
+                    <input
+                        id="{{ $uuid }}"
+                        placeholder = "{{ $attributes->whereStartsWith('placeholder')->first() }} "
+                        x-ref="myInput"
+                        x-model="myInput"
+                        x-on:input="search($event.target.value)"
+
+                        {{
+                            $attributes
+                                ->merge(['type' => 'text'])
+                                ->except(['wire:model', 'required'])
+                                ->class([
+                                    'input input-primary w-full peer',
+                                    'pl-10' => ($icon),
+                                    'h-14' => ($inline),
+                                    'pt-3' => ($inline && $label),
+                                    'rounded-l-none' => $prefix || $prepend,
+                                    'rounded-r-none' => $suffix || $append,
+                                    'border border-dashed' => $attributes->has('readonly') && $attributes->get('readonly') == true,
+                                    'input-error' => $errors->has($modelName())
+                            ])
+                        }}
+                    />
+
+                    <!-- ICON  -->
+                    @if($icon)
+                        <x-icon :name="$icon" class="absolute top-1/2 -translate-y-1/2 left-3 text-gray-400 pointer-events-none" />
+                    @endif
+
+                    <!-- RIGHT ICON  -->
+                    @if($iconRight)
+                        <x-icon :name="$iconRight" class="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 pointer-events-none" />
+                    @endif
+
+                    <!-- INLINE LABEL -->
+                    @if($label && $inline)
+                        <label for="{{ $uuid }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                            {{ $label }}
+                        </label>
+                    @endif
+                </div>
+
+                <!-- SUFFIX/APPEND -->
+                @if($suffix || $append)
+                    <div class="rounded-r-lg flex items-center bg-base-200 @if($suffix) border border-primary border-l-0 px-4 @endif">
+                        {{ $append ?? $suffix }}
+                    </div>
+                @endif
+
+                <!-- END: PREFIX/SUFFIX/APPEND/PREPEND CONTAINER  -->
+                @if($prefix || $suffix || $prepend || $append)
+                    </div>
+                @endif
+
+                <!-- ADD TAG -->
+                <div :class="[open ? 'block' : 'hidden']" class="relative">
+                    <div class="absolute left-0 z-40 mt-2 w-full">
+                        <div class="rounded border border-primary bg-white py-1 text-sm shadow-lg dark:bg-gray-800">
+                            <a class="block cursor-pointer px-4 py-1 text-gray-800 hover:bg-primary hover:text-white dark:text-white" x-on:click.prevent="addTag(myInput)">Add "<span class="font-semibold" x-text="myInput"></span>"</a>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- TAGS -->
+                <div class="mt-2" x-show="tags.length">
+                    <template x-for="(tag, index) in tags">
+                        <div class="btn btn-info btn-sm mb-2 mr-2">
+                            <span x-text="tag"></span>
+                            <button type="button" x-on:click.prevent="removeTag(index)">
+                                <x-icon name="o-x-mark" class="w-4 h-4" />
+                            </button>
+                        </div>
+                    </template>
+                </div>
+
+                <!-- ERROR -->
+                @error($modelName())
+                    <div class="text-red-500 label-text-alt p-1">{{ $message }}</div>
+                @enderror
+
+                <!-- HINT -->
+                @if($hint)
+                    <div class="label-text-alt text-gray-400 p-1 pb-0">{{ $hint }}</div>
+                @endif
+            </div>
+        HTML;
+    }
+}


### PR DESCRIPTION
## Add `Tags` component for managing multiple tags

Introducing the `Tags` component for managing multiple tags. This component allows users to input and manage multiple tags.

### Usage

To use the `Tags` component, simply add the following code to your Blade template:

```html
<x-tags label="Tags" placeholder="Enter Tags..." wire:model="tags" />
```

You can customize the label and placeholder text to fit your application's needs. The `wire:model` attribute allows you to bind the component to a Livewire property for easy data management.

_Please feel free to review the code and provide any feedback or suggestions for improvement._