### PR TITLE
Toast: improvements

### DIFF
--- a/src/Traits/Toast.php
+++ b/src/Traits/Toast.php
@@ -2,32 +2,27 @@
 
 namespace Mary\Traits;
 
+use Blade;
+
 trait Toast
 {
-    public function success(
-        string $title,
-        string $description = null,
-        string $position = 'toast-top toast-end',
-        int $timeout = 3000,
-        string $redirectTo = null
-    ) {
-        return $this->toast('success', $title, $description, $position, $timeout, $redirectTo);
-    }
-
     public function toast(
         string $type,
         string $title,
         string $description = null,
         string $position = 'toast-top toast-end',
+        string $icon = 'o-information-circle',
+        string $css = 'alert-info',
         int $timeout = 3000,
         string $redirectTo = null
     ) {
         $toast = [
-            'css' => $this->config($type)['css'] ?? '',
-            'icon' => $this->config($type)['icon'] ?? 'o-alert-info',
+            'type' => $type,
             'title' => $title,
             'description' => $description,
             'position' => $position,
+            'icon' => Blade::render("<x-mary-icon class='w-7 h-7' name='" . $icon . "' />"),
+            'css' => $css,
             'timeout' => $timeout,
         ];
 
@@ -41,55 +36,51 @@ trait Toast
         }
     }
 
-    private function config($type): array
-    {
-        return [
-            'success' => [
-                'css' => 'alert-success',
-                'icon' => 's-check-circle',
-            ],
-            'warning' => [
-                'css' => 'alert-warning',
-                'icon' => 's-exclamation-triangle',
-            ],
-            'info' => [
-                'css' => 'alert-info',
-                'icon' => 's-information-circle',
-            ],
-            'error' => [
-                'css' => 'alert-error',
-                'icon' => 's-x-circle',
-            ],
-        ][$type] ?? [];
+    public function success(
+        string $title,
+        string $description = null,
+        string $position = 'toast-top toast-end',
+        string $icon = 'o-check-circle',
+        string $css = 'alert-success',
+        int $timeout = 3000,
+        string $redirectTo = null
+    ) {
+        return $this->toast('success', $title, $description, $position, $icon, $css, $timeout, $redirectTo);
     }
 
     public function warning(
         string $title,
         string $description = null,
         string $position = 'toast-top toast-end',
+        string $icon = 'o-exclamation-triangle',
+        string $css = 'alert-warning',
         int $timeout = 3000,
         string $redirectTo = null
     ) {
-        return $this->toast('warning', $title, $description, $position, $timeout, $redirectTo);
+        return $this->toast('warning', $title, $description, $position, $icon, $css, $timeout, $redirectTo);
     }
 
     public function error(
         string $title,
         string $description = null,
         string $position = 'toast-top toast-end',
+        string $icon = 'o-x-circle',
+        string $css = 'alert-error',
         int $timeout = 3000,
         string $redirectTo = null
     ) {
-        return $this->toast('error', $title, $description, $position, $timeout, $redirectTo);
+        return $this->toast('error', $title, $description, $position, $icon, $css, $timeout, $redirectTo);
     }
 
     public function info(
         string $title,
         string $description = null,
         string $position = 'toast-top toast-end',
+        string $icon = 'o-information-circle',
+        string $css = 'alert-info',
         int $timeout = 3000,
         string $redirectTo = null
     ) {
-        return $this->toast('info', $title, $description, $position, $timeout, $redirectTo);
+        return $this->toast('info', $title, $description, $position, $icon, $css, $timeout, $redirectTo);
     }
 }

--- a/src/View/Components/Toast.php
+++ b/src/View/Components/Toast.php
@@ -32,11 +32,12 @@ class Toast extends Component
                         :class="toast.position"
                         x-show="show"
                         @click="show = false"
-                        >
-                        <div class="alert" :class="toast.css">
+                    >
+                        <div class="alert gap-2" :class="toast.css">
+                            <div x-html="toast.icon"></div>
                             <div class="grid">
-                                <div x-text="toast.title" class="font-bold"></div>
-                                <div x-text="toast.description" class="text-xs"></div>
+                                <div x-html="toast.title" class="font-bold"></div>
+                                <div x-html="toast.description" class="text-xs"></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes #148 #149 

- Allow html within `title` and `description`
- Enable default icons
- Allow custom icons


![image](https://github.com/robsontenorio/mary/assets/118955/ed3fb98e-1336-4168-9f4e-abe85a6c8912)


<br><br><br>
<hr />
<hr />
<hr />
<br><br><br>


![image](https://github.com/robsontenorio/mary/assets/118955/916b6a0f-4feb-42e3-a75f-03f2655f70a3)
