### PR TITLE
Button: fix link with HTML entity

### DIFF
--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -45,7 +45,7 @@ class Button extends Component
     {
         return <<<'HTML'
                 @if($link)
-                    <a href="{{ $link }}"
+                    <a href="{!! $link !!}"
                 @else
                     <button
                 @endif


### PR DESCRIPTION
Fix a case where `link` has HTML entity like `/user?param=1&param=2`