### PR TITLE
Button: better spinner handling

### DIFF
--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -80,7 +80,7 @@ class Button extends Component
 
                     <!-- ICON -->
                     @if($icon)
-                        <span @if($spinner) wire:loading.remove wire:target="{{ $spinnerTarget() }}" @endif>
+                        <span class="inline-flex" @if($spinner) wire:loading.remove.class="inline-flex" wire:target="{{ $spinnerTarget() }}" @endif>
                             <x-mary-icon :name="$icon" />
                         </span>
                     @endif
@@ -99,7 +99,7 @@ class Button extends Component
 
                     <!-- ICON RIGHT -->
                     @if($iconRight)
-                        <span @if($spinner) wire:loading.remove wire:target="{{ $spinnerTarget() }}" @endif>
+                        <span class="inline-flex" @if($spinner) wire:loading.remove.class="inline-flex" wire:target="{{ $spinnerTarget() }}" @endif>
                             <x-mary-icon :name="$iconRight" />
                         </span>
                     @endif

--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -73,14 +73,14 @@ class Button extends Component
                     @endif
                 >
 
-                    <!-- SPINNER -->
-                    @if($spinner)
+                    <!-- SPINNER LEFT -->
+                    @if($spinner && !$iconRight)
                         <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
                     @endif
 
                     <!-- ICON -->
                     @if($icon)
-                        <span class="inline-flex" @if($spinner) wire:loading.remove.class="inline-flex" wire:target="{{ $spinnerTarget() }}" @endif>
+                        <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
                             <x-mary-icon :name="$icon" />
                         </span>
                     @endif
@@ -99,9 +99,14 @@ class Button extends Component
 
                     <!-- ICON RIGHT -->
                     @if($iconRight)
-                        <span class="inline-flex" @if($spinner) wire:loading.remove.class="inline-flex" wire:target="{{ $spinnerTarget() }}" @endif>
+                        <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
                             <x-mary-icon :name="$iconRight" />
                         </span>
+                    @endif
+
+                    <!-- SPINNER RIGHT -->
+                    @if($spinner && $iconRight)
+                        <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
                     @endif
 
                 @if(!$link)


### PR DESCRIPTION
- Fix an issue when button have a `icon` + `spinner`  and error is thrown (default Livewire error modal), then icon disappear.
- Allow spinner for right icon.