### PR TITLE
Input: fix `x-ref` if not using `money`

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -78,9 +78,9 @@ class Input extends Component
                     <input
                         id="{{ $uuid }}"
                         placeholder = "{{ $attributes->whereStartsWith('placeholder')->first() }} "
-                        x-ref="myInput"
 
                         @if($money)
+                            x-ref="myInput"
                             :value="amount"
                             @input="$nextTick(() => $wire.{{ $modelName() }} = Currency.getUnmasked())"
                             inputmode="numeric"


### PR DESCRIPTION
Fix #172 

- Fix weird issue when `x-ref` is placed but not used.