### PR TITLE
Table: fix `selectable` for pagination

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -40,6 +40,11 @@ class Table extends Component
     // Get all ids for selectable and expandable features
     public function getAllIds(): array
     {
+        // Pagination
+        if ($this->rows instanceof ArrayAccess) {
+            return $this->rows->pluck($this->selectableKey)->all();
+        }
+
         return collect($this->rows)->pluck($this->selectableKey)->all();
     }
 


### PR DESCRIPTION
Fix #171 

Fix `select all` when `rows` is paginated.