### PR TITLE
Choices: improvements

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -167,7 +167,7 @@ class Choices extends Component
                             @click="focus()"
 
                             {{
-                                $attributes->except('wire:model')->class([
+                                $attributes->except(['wire:model', 'wire:model.live'])->class([
                                     "select select-bordered select-primary w-full h-fit pr-16 pb-1 pt-1.5 inline-block cursor-pointer relative",
                                     'border border-dashed' => $isReadonly(),
                                     'select-error' => $errors->has($modelName()),


### PR DESCRIPTION
Fix #191  #188 

- Add `selection` slot.
- Allow `wire:model.live`.
- Fix issue when key value starts with ZERO.

<img width="876" alt="image" src="https://github.com/robsontenorio/mary/assets/118955/54f29623-1dc4-40ca-96e4-8a0b7858257b">
