### PR TITLE
Fix double quote in header component

### DIFF
--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -38,7 +38,7 @@ class Header extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div id="{{ $anchor }}" {{ $attributes->class(["mb-10", "mary-header-anchor" => $withAnchor]) }}">
+                <div id="{{ $anchor }}" {{ $attributes->class(["mb-10", "mary-header-anchor" => $withAnchor]) }}>
                     <div class="flex flex-wrap gap-5 justify-between items-center">
                         <div>
                             <div @class(["$size font-extrabold", is_string($title) ? '' : $title?->attributes->get('class') ]) >


### PR DESCRIPTION
The header component generates two double quotes at the end of the attributes:

![Screenshot 2023-12-10 120116](https://github.com/robsontenorio/mary/assets/9197177/18b2e607-463a-47b7-85e2-9eb215e17095)

After the change in this PR:

![Screenshot 2023-12-10 120212](https://github.com/robsontenorio/mary/assets/9197177/8ddee94a-150d-40af-8a9e-955b083f76c3)
