### PR TITLE
Fix tailwind force, remove dynamic class names

### DIFF
--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -10,7 +10,7 @@ class Button extends Component
 {
     public string $uuid;
 
-    public string $tooltipPosition = 'tooltip-top';
+    public string $tooltipPosition = 'lg:tooltip-top';
 
     public function __construct(
         public ?string $label = null,
@@ -30,7 +30,7 @@ class Button extends Component
     ) {
         $this->uuid = md5(serialize($this));
         $this->tooltip = $this->tooltip ?? $this->tooltipLeft ?? $this->tooltipRight ?? $this->tooltipBottom;
-        $this->tooltipPosition = $this->tooltipLeft ? 'tooltip-left' : ($this->tooltipRight ? 'tooltip-right' : ($this->tooltipBottom ? 'tooltip-bottom' : 'tooltip-top'));
+        $this->tooltipPosition = $this->tooltipLeft ? 'lg:tooltip-left' : ($this->tooltipRight ? 'lg:tooltip-right' : ($this->tooltipBottom ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }
 
     public function spinnerTarget(): ?string
@@ -53,7 +53,7 @@ class Button extends Component
 
                     wire:key="{{ $uuid }}"
                     {{ $attributes->whereDoesntStartWith('class') }}
-                    {{ $attributes->class(['btn normal-case', "!inline-flex lg:tooltip lg:$tooltipPosition" => $tooltip]) }}
+                    {{ $attributes->class(['btn normal-case', "!inline-flex lg:tooltip $tooltipPosition" => $tooltip]) }}
                     {{ $attributes->merge(['type' => 'button']) }}
 
                     @if($link && $external)
@@ -115,11 +115,6 @@ class Button extends Component
                 @else
                     </a>
                 @endif
-
-                <!--  Force tailwind compile tooltip classes   -->
-                <span class="hidden">
-                    <span class="lg:tooltip lg:tooltip-left lg:tooltip-right lg:tooltip-bottom lg:tooltip-top"></span>
-                </span>
             HTML;
     }
 }

--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -52,9 +52,8 @@ class Button extends Component
                 @endif
 
                     wire:key="{{ $uuid }}"
-                    {{ $attributes->whereDoesntStartWith('class') }}
+                    {{ $attributes->whereDoesntStartWith('class')->merge(['type' => 'button']) }}
                     {{ $attributes->class(['btn normal-case', "!inline-flex lg:tooltip $tooltipPosition" => $tooltip]) }}
-                    {{ $attributes->merge(['type' => 'button']) }}
 
                     @if($link && $external)
                         target="_blank"

--- a/src/View/Components/Stat.php
+++ b/src/View/Components/Stat.php
@@ -10,7 +10,7 @@ class Stat extends Component
 {
     public string $uuid;
 
-    public string $tooltipPosition = 'tooltip-top';
+    public string $tooltipPosition = 'lg:tooltip-top';
 
     public function __construct(
         public ?string $value = null,
@@ -26,14 +26,14 @@ class Stat extends Component
     ) {
         $this->uuid = md5(serialize($this));
         $this->tooltip = $this->tooltip ?? $this->tooltipLeft ?? $this->tooltipRight ?? $this->tooltipBottom;
-        $this->tooltipPosition = $this->tooltipLeft ? 'tooltip-left' : ($this->tooltipRight ? 'tooltip-right' : ($this->tooltipBottom ? 'tooltip-bottom' : 'tooltip-top'));
+        $this->tooltipPosition = $this->tooltipLeft ? 'lg:tooltip-left' : ($this->tooltipRight ? 'lg:tooltip-right' : ($this->tooltipBottom ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
                 <div
-                    {{ $attributes->class(["bg-base-100 rounded-lg px-5 py-4  w-full", "lg:tooltip lg:$tooltipPosition" => $tooltip]) }}
+                    {{ $attributes->class(["bg-base-100 rounded-lg px-5 py-4  w-full", "lg:tooltip $tooltipPosition" => $tooltip]) }}
 
                     @if($tooltip)
                         data-tip="{{ $tooltip }}"
@@ -58,11 +58,6 @@ class Stat extends Component
                             @endif
                         </div>
                     </div>
-
-                    <!--  Force tailwind compile tooltip classes   -->
-                    <span class="hidden">
-                        <span class="lg:tooltip lg:tooltip-left lg:tooltip-right lg:tooltip-bottom lg:tooltip-top"></span>
-                    </span>
                 </div>
             HTML;
     }

--- a/src/View/Components/Toast.php
+++ b/src/View/Components/Toast.php
@@ -31,6 +31,7 @@ class Toast extends Component
                         class="toast rounded-md fixed cursor-pointer z-50"
                         :class="toast.position"
                         x-show="show"
+                        x-classes="top-10 right-10 toast toast-bottom toast-center toast-middle toast-start"
                         @click="show = false"
                     >
                         <div class="alert gap-2" :class="toast.css">
@@ -42,9 +43,6 @@ class Toast extends Component
                         </div>
                     </div>
                 </div>
-
-                <!-- Force Tailwind compile alert types -->
-                <span class="hidden alert alert-success alert-warning alert-error alert-info top-10 right-10 toast toast-top toast-bottom toast-center toast-end toast-middle toast-start"></span>
 
                 <script>
                     window.toast = function(payload){

--- a/src/View/Components/Toast.php
+++ b/src/View/Components/Toast.php
@@ -31,7 +31,7 @@ class Toast extends Component
                         class="toast rounded-md fixed cursor-pointer z-50"
                         :class="toast.position"
                         x-show="show"
-                        x-classes="top-10 right-10 toast toast-bottom toast-center toast-middle toast-start"
+                        x-classes="alert alert-success alert-warning alert-error alert-info top-10 right-10 toast toast-top toast-bottom toast-center toast-end toast-middle toast-start"
                         @click="show = false"
                     >
                         <div class="alert gap-2" :class="toast.css">


### PR DESCRIPTION
When using multiple buttons as group, using daisyUI's [Join Component](https://daisyui.com/components/join/) I found an issue where the last button doesn't have a rounded border.

![Screenshot 2023-12-10 161110](https://github.com/robsontenorio/mary/assets/9197177/5590508a-8bb3-4a46-876f-7941a3cdc947)

After checking the code I came to the conclusion this was caused because of the hidden `span` that was added after the button. As last element in the Join Component the `span` got the rounded border.

As far as I could find (and suggested by the comment) this `span` in the `Button` and `Stat` component is only used for the builder, because the classes of the `span` are not anywhere else in the code. Tailwind advises againt the use of [dynamic class names](https://tailwindcss.com/docs/content-configuration#dynamic-class-names).

For the `Button` and `Stat` component this is a straight forward fix, because the correct classes can be added in `$tooltipPosition`. For the `Toast` component I saw no other option than to use a custom attribute.

The result with the button group is now as expected:

![Screenshot 2023-12-10 173530](https://github.com/robsontenorio/mary/assets/9197177/7a43bbc7-af73-4f70-9ee2-cd937e8935db)

Example code:
```blade
<div class="join" role="group">
    <x-button label="Play" class="btn-warning join-item" icon="s-play" />
    <x-button label="Stop" class="btn-warning join-item" icon="s-stop" />
</div>
```

Also fixed the source for the `Button` component where the `class` attribute was added twice. Before and after:

![Screenshot 2023-12-10 171252](https://github.com/robsontenorio/mary/assets/9197177/f2177f25-f26c-4a42-be8e-11f887c9ba6a)
![Screenshot 2023-12-10 171333](https://github.com/robsontenorio/mary/assets/9197177/5e93f510-08ba-4433-8039-af2d8c064269)
