### PR TITLE
Choices/ChoicesOffline/Tags: fix `wire:navigate` back

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -85,6 +85,13 @@ class Choices extends Component
                             isRequired: {{ json_encode($isRequired()) }},
                             minChars: {{ $minChars }},
 
+                            init() {
+                                // TODO: fix weird issue when navigating back 
+                                document.addEventListener('livewire:navigating', () => {
+                                    let elements = document.querySelectorAll('.mary-choices-element');
+                                    elements.forEach(el =>  el.remove());
+                                });
+                            },
                             get selectedOptions() {
                                 return this.isSingle
                                     ? this.options.filter(i => i.{{ $optionValue }} == this.selection)
@@ -209,7 +216,7 @@ class Choices extends Component
                                     </div>
                                 @else
                                     <template x-for="(option, index) in selectedOptions" :key="index">
-                                        <div class="bg-primary/5 text-primary hover:bg-primary/10 dark:bg-primary/20 dark:hover:bg-primary/40 dark:text-inherit px-2 mr-2 mt-0.5 mb-1.5 last:mr-0 inline-block rounded cursor-pointer">
+                                        <div class="mary-choices-element bg-primary/5 text-primary hover:bg-primary/10 dark:bg-primary/20 dark:hover:bg-primary/40 dark:text-inherit px-2 mr-2 mt-0.5 mb-1.5 last:mr-0 inline-block rounded cursor-pointer">
                                             <!-- SELECTION SLOT -->
                                              @if($selection)
                                                 <span x-html="document.getElementById('selection-{{ $uuid . '-\' + option.'. $optionValue }}).innerHTML"></span>

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -86,7 +86,7 @@ class Choices extends Component
                             minChars: {{ $minChars }},
 
                             init() {
-                                // TODO: fix weird issue when navigating back 
+                                // Fix weird issue when navigating back
                                 document.addEventListener('livewire:navigating', () => {
                                     let elements = document.querySelectorAll('.mary-choices-element');
                                     elements.forEach(el =>  el.remove());

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -79,7 +79,7 @@ class ChoicesOffline extends Component
                             search: '',
 
                             init() {
-                                // TODO: fix weird issue when navigating back
+                                // Fix weird issue when navigating back
                                 document.addEventListener('livewire:navigating', () => {
                                     let elements = document.querySelectorAll('.mary-choices-element');
                                     elements.forEach(el =>  el.remove());

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -78,6 +78,13 @@ class ChoicesOffline extends Component
                             minChars: {{ $minChars }},
                             search: '',
 
+                            init() {
+                                // TODO: fix weird issue when navigating back
+                                document.addEventListener('livewire:navigating', () => {
+                                    let elements = document.querySelectorAll('.mary-choices-element');
+                                    elements.forEach(el =>  el.remove());
+                                });
+                            },
                             get selectedOptions() {
                                 return this.isSingle
                                     ? this.options.filter(i => i.{{ $optionValue }} == this.selection)
@@ -191,7 +198,7 @@ class ChoicesOffline extends Component
                             <!-- SELECTION SLOT (render ahead of time to make it available for custom selection slot)-->
                             @if($selection)
                                 <template x-for="(option, index) in searchOptions" :key="index">
-                                    <span x-bind:id="`selection-{{ $uuid}}-${option.{{ $optionValue }}}`" class="hidden">
+                                    <span x-bind:id="`selection-{{ $uuid}}-${option.{{ $optionValue }}}`" class="hidden mary-choices-element">
                                         {{ $selection }}
                                     </span>
                                 </template>
@@ -205,7 +212,7 @@ class ChoicesOffline extends Component
                                     </div>
                                 @else
                                     <template x-for="(option, index) in selectedOptions" :key="index">
-                                        <div class="bg-primary/5 text-primary hover:bg-primary/10 dark:bg-primary/20 dark:hover:bg-primary/40 dark:text-inherit px-2 mr-2 mt-0.5 mb-1.5 last:mr-0 inline-block rounded cursor-pointer">
+                                        <div class="mary-choices-element bg-primary/5 text-primary hover:bg-primary/10 dark:bg-primary/20 dark:hover:bg-primary/40 dark:text-inherit px-2 mr-2 mt-0.5 mb-1.5 last:mr-0 inline-block rounded cursor-pointer">
                                             <!-- SELECTION SLOT -->
                                              @if($selection)
                                                 <span x-html="document.getElementById('selection-{{ $uuid . '-\' + option.'. $optionValue }}).innerHTML"></span>
@@ -275,7 +282,7 @@ class ChoicesOffline extends Component
                                     <div
                                         @click="toggle(option.{{ $optionValue }})"
                                         :class="isActive(option.{{ $optionValue }}) && 'border-l-4 border-l-primary'"
-                                        class="border-l-4"
+                                        class="mary-choices-element border-l-4"
                                     >
                                         <!-- ITEM SLOT -->
                                         @if($item)

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -42,6 +42,17 @@ class Tags extends Component
                     isReadonly: {{ json_encode($isReadonly()) }},
                     isRequired: {{ json_encode($isRequired()) }},
 
+                    init() {
+                        if (this.tags == null || !Array.isArray(this.tags)) {
+                            this.tags = [];
+                        }
+
+                        // TODO: fix weird issue when navigating back
+                        document.addEventListener('livewire:navigating', () => {
+                            let elements = document.querySelectorAll('.mary-tags-element');
+                            elements.forEach(el =>  el.remove());
+                        });
+                    },
                     push() {
                         if (this.tag != '' && this.tag != null && this.tag != undefined) {
                             let tag = this.tag.toString().replace(/,/g, '').trim()
@@ -78,13 +89,7 @@ class Tags extends Component
                         }
 
                         $refs.searchInput.focus()
-                    },
-
-                    init() {
-                        if (this.tags == null || !Array.isArray(this.tags)) {
-                            this.tags = [];
-                        }
-                    },
+                    }
                 }"
                 @keydown.escape="clear()"
             >
@@ -119,7 +124,7 @@ class Tags extends Component
                     <!--  TAGS  -->
                     <span wire:key="tags-{{ $uuid }}">
                         <template :key="index" x-for="(tag, index) in tags">
-                            <div class="bg-primary/5 text-primary hover:bg-primary/10 dark:bg-primary/20 dark:hover:bg-primary/40 dark:text-inherit px-2 mr-2 mt-0.5 mb-1.5 last:mr-0 inline-block rounded cursor-pointer">
+                            <div class="mary-tags-element bg-primary/5 text-primary hover:bg-primary/10 dark:bg-primary/20 dark:hover:bg-primary/40 dark:text-inherit px-2 mr-2 mt-0.5 mb-1.5 last:mr-0 inline-block rounded cursor-pointer">
                                 <span x-text="tag"></span>
                                 <x-mary-icon @click="remove(index)" x-show="!isReadonly" name="o-x-mark" class="text-gray-500 hover:text-red-500" />
                             </div>

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -47,7 +47,7 @@ class Tags extends Component
                             this.tags = [];
                         }
 
-                        // TODO: fix weird issue when navigating back
+                        // Fix weird issue when navigating back
                         document.addEventListener('livewire:navigating', () => {
                             let elements = document.querySelectorAll('.mary-tags-element');
                             elements.forEach(el =>  el.remove());


### PR DESCRIPTION
Fix a weird element duplication when using wire:navigate and click browse back button.

- Choices
- ChoicesOffline
- Tags