### PR TITLE
Fix for use of invalid HTML id attribute

### DIFF
--- a/src/Traits/WithHtmlId.php
+++ b/src/Traits/WithHtmlId.php
@@ -2,6 +2,7 @@
 
 namespace Mary\Traits;
 
+use Exception;
 use Illuminate\Support\Str;
 
 trait WithHtmlId
@@ -10,6 +11,10 @@ trait WithHtmlId
 
     public function setHtmlId(string $prefix, ?string $value = null): void
     {
+        if (preg_match('/^[a-z]/i', $prefix) !== 1) {
+            throw new Exception('Prefix must start with a letter.');
+        }
+
         $this->htmlId = sprintf(
             '%s-%s',
             $prefix,

--- a/src/Traits/WithHtmlId.php
+++ b/src/Traits/WithHtmlId.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Str;
 
 trait WithHtmlId
 {
-    public string $htmlId;
+    public string $htmlId = 'element';
 
-    public function setHtmlId(string $prefix, ?string $value = null)
+    public function setHtmlId(string $prefix, ?string $value = null): void
     {
         $this->htmlId = sprintf(
             '%s-%s',

--- a/src/Traits/WithHtmlId.php
+++ b/src/Traits/WithHtmlId.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Mary\Traits;
+
+use Illuminate\Support\Str;
+
+trait WithHtmlId
+{
+    public string $htmlId;
+
+    public function setHtmlId(string $prefix, ?string $value = null)
+    {
+        $this->htmlId = sprintf(
+            '%s-%s',
+            $prefix,
+            $value ?? $this->uuid ?? Str::uuid(),
+        );
+    }
+}

--- a/src/Traits/WithUuid.php
+++ b/src/Traits/WithUuid.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mary\Traits;
+
+trait WithUuid
+{
+    public string $uuid;
+
+    public function setUuid(string $uuid)
+    {
+        $this->uuid = $uuid;
+    }
+}

--- a/src/Traits/WithUuid.php
+++ b/src/Traits/WithUuid.php
@@ -6,7 +6,7 @@ trait WithUuid
 {
     public string $uuid;
 
-    public function setUuid(string $uuid)
+    public function setUuid(string $uuid): void
     {
         $this->uuid = $uuid;
     }

--- a/src/View/Components/DateTime.php
+++ b/src/View/Components/DateTime.php
@@ -5,10 +5,13 @@ namespace Mary\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
+use Mary\Traits\WithHtmlId;
+use Mary\Traits\WithUuid;
 
 class DateTime extends Component
 {
-    public string $uuid;
+    use WithHtmlId;
+    use WithUuid;
 
     public function __construct(
         public ?string $label = null,
@@ -17,7 +20,8 @@ class DateTime extends Component
         public ?string $hint = null,
         public ?bool $inline = false,
     ) {
-        $this->uuid = md5(serialize($this));
+        $this->setUuid(md5(serialize($this)));
+        $this->setHtmlId('date-picker');
     }
 
     public function modelName(): ?string
@@ -31,7 +35,7 @@ class DateTime extends Component
              <div>
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <label for="{{ $htmlId }}" class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -44,7 +48,7 @@ class DateTime extends Component
 
                 <div class="flex-1 relative">
                     <input
-                        id="{{ $uuid }}"
+                        id="{{ $htmlId }}"
 
                         {{ $attributes
                                 ->merge(['type' => 'date'])
@@ -71,7 +75,7 @@ class DateTime extends Component
 
                     <!-- INLINE LABEL -->
                     @if($label && $inline)
-                        <label for="{{ $uuid }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] bg-white rounded dark:bg-gray-900 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                        <label for="{{ $htmlId }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] bg-white rounded dark:bg-gray-900 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
                             {{ $label }}
                         </label>
                     @endif

--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -5,10 +5,13 @@ namespace Mary\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
+use Mary\Traits\WithHtmlId;
+use Mary\Traits\WithUuid;
 
 class File extends Component
 {
-    public string $uuid;
+    use WithHtmlId;
+    use WithUuid;
 
     public function __construct(
         public ?string $label = null,
@@ -16,7 +19,8 @@ class File extends Component
         public ?bool $hideErrors = false,
         public ?bool $hideProgress = false,
     ) {
-        $this->uuid = md5(serialize($this));
+        $this->setUuid(md5(serialize($this)));
+        $this->setHtmlId('file');
     }
 
     public function modelName(): ?string
@@ -52,7 +56,7 @@ class File extends Component
 
                     <!-- FILE INPUT -->
                     <input
-                        id="{{ $uuid }}"
+                        id="{{ $htmlId }}"
                         type="file"
                         {{
                             $attributes->class([
@@ -63,7 +67,7 @@ class File extends Component
                     />
 
                     @if ($slot->isNotEmpty())
-                        <label for="{{ $uuid }}">{{ $slot }}</label>
+                        <label for="{{ $htmlId }}">{{ $slot }}</label>
                     @endif
 
                     <!-- ERROR -->

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -5,10 +5,13 @@ namespace Mary\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
+use Mary\Traits\WithHtmlId;
+use Mary\Traits\WithUuid;
 
 class Input extends Component
 {
-    public string $uuid;
+    use WithHtmlId;
+    use WithUuid;
 
     public function __construct(
         public ?string $label = null,
@@ -27,7 +30,8 @@ class Input extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = md5(serialize($this));
+        $this->setUuid(md5(serialize($this)));
+        $this->setHtmlId('input');
     }
 
     public function modelName(): ?string
@@ -51,7 +55,7 @@ class Input extends Component
             <div>
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <label for="{{ $htmlId }}" class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -85,7 +89,7 @@ class Input extends Component
 
                     <!-- INPUT -->
                     <input
-                        id="{{ $uuid }}"
+                        id="{{ $htmlId }}"
                         placeholder = "{{ $attributes->whereStartsWith('placeholder')->first() }} "
 
                         @if($money)
@@ -129,7 +133,7 @@ class Input extends Component
 
                     <!-- INLINE LABEL -->
                     @if($label && $inline)
-                        <label for="{{ $uuid }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                        <label for="{{ $htmlId }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
                             {{ $label }}
                         </label>
                     @endif

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -6,10 +6,13 @@ use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\View\Component;
+use Mary\Traits\WithHtmlId;
+use Mary\Traits\WithUuid;
 
 class Select extends Component
 {
-    public string $uuid;
+    use WithHtmlId;
+    use WithUuid;
 
     public function __construct(
         public ?string $label = null,
@@ -27,7 +30,8 @@ class Select extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = md5(serialize($this));
+        $this->setUuid(md5(serialize($this)));
+        $this->setHtmlId('select');
     }
 
     public function modelName(): ?string
@@ -41,7 +45,7 @@ class Select extends Component
             <div>
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <label for="{{ $htmlId }}" class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -66,7 +70,7 @@ class Select extends Component
 
                 <div class="relative flex-1">
                     <select
-                        id="{{ $uuid }}"
+                        id="{{ $htmlId }}"
                         {{ $attributes->whereDoesntStartWith('class') }}
                         {{ $attributes->class([
                                     'select select-primary w-full font-normal',
@@ -101,7 +105,7 @@ class Select extends Component
 
                     <!-- INLINE LABEL -->
                     @if($label && $inline)
-                        <label for="{{ $uuid }}" class="absolute pointer-events-none text-gray-500 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                        <label for="{{ $htmlId }}" class="absolute pointer-events-none text-gray-500 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded bg-base-100 px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
                             {{ $label }}
                         </label>
                     @endif

--- a/src/View/Components/Tab.php
+++ b/src/View/Components/Tab.php
@@ -22,7 +22,7 @@ class Tab extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                    @aware(['tabContainer' =>  ''])
+                    @aware(['htmlId' =>  ''])
                     <a
                         @click="selected = '{{ $name }}'"
                         class="tab tab-bordered flex-none font-semibold"
@@ -38,7 +38,7 @@ class Tab extends Component
                     </a>
 
                     <div wire:key="{{ $name }}-{{ rand() }}">
-                        <template x-teleport="#{{ $tabContainer }}">
+                        <template x-teleport="#{{ $htmlId }}">
                             <div x-show="selected === '{{ $name }}'" {{ $attributes->class(['py-5']) }}>
                                 {{ $slot }}
                             </div>

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -5,17 +5,20 @@ namespace Mary\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
+use Mary\Traits\WithHtmlId;
+use Mary\Traits\WithUuid;
 
 class Tabs extends Component
 {
-    public string $uuid;
+    use WithUuid;
+    use WithHtmlId;
 
     public function __construct(
         public ?string $selected = null,
         public string $tabContainer = ''
     ) {
-        $this->uuid = md5(serialize($this));
-        $this->tabContainer = sprintf('tabs-%s', $this->uuid);
+        $this->setUuid(md5(serialize($this)));
+        $this->setHtmlId('tabs');
     }
 
     public function render(): View|Closure|string
@@ -36,7 +39,7 @@ class Tabs extends Component
                         {{ $slot }}
                     </div>
                     <hr/>
-                    <div id="{{ $tabContainer }}">
+                    <div id="{{ $htmlId }}">
                             <!-- tab contents will be teleported in here -->
                     </div>
                 HTML;

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -10,8 +10,8 @@ use Mary\Traits\WithUuid;
 
 class Tabs extends Component
 {
-    use WithUuid;
     use WithHtmlId;
+    use WithUuid;
 
     public function __construct(
         public ?string $selected = null,

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -15,7 +15,7 @@ class Tabs extends Component
         public string $tabContainer = ''
     ) {
         $this->uuid = md5(serialize($this));
-        $this->tabContainer = $this->uuid;
+        $this->tabContainer = sprintf('tabs-%s', $this->uuid);
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -5,17 +5,21 @@ namespace Mary\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
+use Mary\Traits\WithHtmlId;
+use Mary\Traits\WithUuid;
 
 class Tags extends Component
 {
-    public string $uuid;
+    use WithHtmlId;
+    use WithUuid;
 
     public function __construct(
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $icon = null,
     ) {
-        $this->uuid = md5(serialize($this));
+        $this->setUuid(md5(serialize($this)));
+        $this->setHtmlId('tags');
     }
 
     public function modelName(): ?string
@@ -95,7 +99,7 @@ class Tags extends Component
             >
                 <!-- STANDARD LABEL -->
                 @if ($label)
-                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <label for="{{ $htmlId }}" class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -143,7 +147,7 @@ class Tags extends Component
 
                     <!-- INPUT -->
                     <input
-                        id="{{ $uuid }}"
+                        id="{{ $htmlId }}"
                         class="outline-none mt-1 bg-transparent"
                         placeholder="{{ $attributes->whereStartsWith('placeholder')->first() }}"
                         type="text"


### PR DESCRIPTION
When working with the tabs it was not possible to get them to work unless I used the code from the example in the [documentation](https://mary-ui.com/docs/components/tabs).

The following message returned in the browser console:

```console
Uncaught DOMException: Document.querySelector: '#8192874ab96e164e8e6767302891308c' is not a valid selector
    target http://localhost:8000/livewire/livewire.js?id=8a199ab2:2854
    skipDuringClone http://localhost:8000/livewire/livewire.js?id=8a199ab2:1632
    getTarget http://localhost:8000/livewire/livewire.js?id=8a199ab2:2857
    <anonymous> http://localhost:8000/livewire/livewire.js?id=8a199ab2:2814
    flushHandlers http://localhost:8000/livewire/livewire.js?id=8a199ab2:1135
    stopDeferring http://localhost:8000/livewire/livewire.js?id=8a199ab2:1140
    deferHandlingDirectives http://localhost:8000/livewire/livewire.js?id=8a199ab2:1143
    initTree http://localhost:8000/livewire/livewire.js?id=8a199ab2:654
    start http://localhost:8000/livewire/livewire.js?id=8a199ab2:609
    start http://localhost:8000/livewire/livewire.js?id=8a199ab2:608
    start2 http://localhost:8000/livewire/livewire.js?id=8a199ab2:8283
    <anonymous> http://localhost:8000/livewire/livewire.js?id=8a199ab2:9401
    EventListener.handleEvent* http://localhost:8000/livewire/livewire.js?id=8a199ab2:9400
    <anonymous> http://localhost:8000/livewire/livewire.js?id=8a199ab2:9404
[l](http://localhost:8000/livewire/livewire.js?id=8a199ab2)
```

The error arises because the `id` of the element in some cases starts with a number. This is a result of using the md5 function to generate the UUID.

For a `label` + `input` it does not matter much if the `id` attribute starts with a number. If the `id` is used in, for example, a selector in JavaScript, it does matter.

> Technically, the value for an id attribute may contain any character, except [whitespace](https://developer.mozilla.org/en-US/docs/Glossary/Whitespace) characters. However, to avoid inadvertent errors, only [ASCII](https://developer.mozilla.org/en-US/docs/Glossary/ASCII) letters, digits, '_', and '-' should be used, **and the value for an id attribute should start with a letter**.

[Source](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)

This PR ensures that the `id` attribute always starts with a letter. Not only with the tabs, but also with the other components where the uuid is placed in the html `id` attribute.

Use the following view to test. The second set of tabs doesn't work for me on the `main` branch, but it does on PR.
[fix-tabs.blade.zip](https://github.com/robsontenorio/mary/files/13695483/fix-tabs.blade.zip)