### PR TITLE
Ignore displaying asterisk when "required" is false

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -172,7 +172,7 @@ class Choices extends Component
                                 <span>
                                     {{ $label }}
 
-                                    @if($attributes->has('required'))
+                                    @if($attributes->get('required'))
                                         <span class="text-error">*</span>
                                     @endif
                                 </span>

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -159,7 +159,7 @@ class ChoicesOffline extends Component
                                 <span>
                                     {{ $label }}
 
-                                    @if($attributes->has('required'))
+                                    @if($attributes->get('required'))
                                         <span class="text-error">*</span>
                                     @endif
                                 </span>

--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -51,7 +51,7 @@ class DatePicker extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required'))
+                            @if($attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>

--- a/src/View/Components/DateTime.php
+++ b/src/View/Components/DateTime.php
@@ -35,7 +35,7 @@ class DateTime extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required'))
+                            @if($attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -55,7 +55,7 @@ class Input extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required'))
+                            @if($attributes->has('required') && $attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -55,7 +55,7 @@ class Input extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required') && $attributes->get('required'))
+                            @if($attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>

--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -35,7 +35,7 @@ class Radio extends Component
                             <span>
                                 {{ $label }}
 
-                                @if($attributes->has('required'))
+                                @if($attributes->get('required'))
                                     <span class="text-error">*</span>
                                 @endif
                             </span>

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -45,7 +45,7 @@ class Select extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required'))
+                            @if($attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -99,7 +99,7 @@ class Tags extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required'))
+                            @if($attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -33,7 +33,7 @@ class Textarea extends Component
                         <span>
                             {{ $label }}
 
-                            @if($attributes->has('required'))
+                            @if($attributes->get('required'))
                                 <span class="text-error">*</span>
                             @endif
                         </span>


### PR DESCRIPTION
Fixed a bug where the asterisk (*) was always shown, ignoring the "required" attribute boolean value.

## Before
```php
<x-input :required="false" label="Name" wire:model="name" />
```
![image](https://github.com/robsontenorio/mary/assets/44245907/f631030e-4be6-4c5a-b1bf-052a6ddb13db)

## After
```php
<x-input :required="false" label="Name" wire:model="name" />
```
![image](https://github.com/robsontenorio/mary/assets/44245907/3ddd7d51-62a6-4ff1-b096-306fdb49be5b)

```php
<x-input :required="true" label="Name" wire:model="name" />
```
```php
<x-input required label="Name" wire:model="name" />
```
![image](https://github.com/robsontenorio/mary/assets/44245907/46a69505-c370-4889-a12c-d39cd4e0349e)
