### PR TITLE
Input: fix `clearable` for `live` modifiers

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -119,7 +119,7 @@ class Input extends Component
 
                     <!-- CLEAR ICON  -->
                     @if($clearable)
-                        <x-mary-icon @click="$wire.set('{{ $modelName() }}', '', {{ json_encode($attributes->has('wire:model.live')) }})"  name="o-x-mark" class="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-600" />
+                        <x-mary-icon @click="$wire.set('{{ $modelName() }}', '', {{ json_encode($attributes->wire('model')->hasModifier('live')) }})"  name="o-x-mark" class="absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-600" />
                     @endif
 
                     <!-- RIGHT ICON  -->


### PR DESCRIPTION
Fix a case when is used with modifiers like `wire:model.live.debounce`