### PR TITLE
Input: fix array models

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -49,6 +49,11 @@ class Input extends Component
     {
         return <<<'HTML'
             <div>
+                @php
+                    // Wee need this extra step to support models arrays. Ex: wire:model="emails.0"  , wire:model="emails.1"
+                    $uuid = $uuid . $modelName()
+                @endphp
+
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
                     <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">


### PR DESCRIPTION
Fix #242 

Support models arrays. Ex: wire:model="emails.0"  , wire:model="emails.1"