### PR TITLE
Select: fix array model

### DIFF
--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -39,6 +39,11 @@ class Select extends Component
     {
         return <<<'HTML'
             <div>
+                 @php
+                     // Wee need this extra step to support models arrays. Ex: wire:model="emails.0"  , wire:model="emails.1"
+                     $uuid = $uuid . $modelName()
+                 @endphp
+            
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
                     <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">


### PR DESCRIPTION
Fix #242 

Support models arrays. Ex: wire:model="emails.0" , wire:model="emails.1"