### PR TITLE
Adding opacity 0 to checkbox in theme toggle

### DIFF
--- a/src/View/Components/ThemeToggle.php
+++ b/src/View/Components/ThemeToggle.php
@@ -44,7 +44,7 @@ class ThemeToggle extends Component
                         @mary-toggle-theme.window="toggle()"
                         {{ $attributes->class("swap swap-rotate") }}
                     >
-                        <input type="checkbox" class="theme-controller" @click="toggle()" :value="theme" />
+                        <input type="checkbox" class="theme-controller opacity-0" @click="toggle()" :value="theme" />
                         <x-mary-icon x-ref="sun" name="o-sun" class="swap-on" />
                         <x-mary-icon x-ref="moon" name="o-moon" class="swap-off"  />
                     </label>


### PR DESCRIPTION
HI i used the new compoent and sow that the checkbox under the theme icon was still visible, so i put an opacity-0 proprerty to the chckbox