### PR TITLE
Choices: add `@change-selection` event

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -127,7 +127,7 @@ class Choices extends Component
                                     ? this.selection = null
                                     : this.selection = []
                                 
-                                this.dispatchChangeEvent({ value: this.isSingle ? null : []})
+                                this.dispatchChangeEvent({ value: this.selection})
                             },
                             focus() {
                                 if (this.isReadonly) {

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -47,11 +47,6 @@ class Choices extends Component
         }
     }
 
-    public function onChangeFunc(): string | null
-    {
-        return $this->attributes->whereStartsWith('@change')->first();
-    }
-
     public function modelName(): string
     {
         return $this->attributes->wire('model')->value();
@@ -89,10 +84,6 @@ class Choices extends Component
                             isReadonly: {{ json_encode($isReadonly()) }},
                             isRequired: {{ json_encode($isRequired()) }},
                             minChars: {{ $minChars }},
-                            onChange: (id) => {
-                                $value = id;
-                                {{ $onChangeFunc() }}
-                            },
 
                             init() {
                                 // Fix weird issue when navigating back
@@ -163,10 +154,15 @@ class Choices extends Component
                                         : this.selection.push(id)
                                 }
 
-                                this.onChange(this.selection)
-
                                 this.$refs.searchInput.value = ''
                                 this.$refs.searchInput.focus()
+                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change', {
+                                    bubbles: true, 
+                                    detail: {
+                                        target: this.$refs.searchInput,
+                                        value: this.selection
+                                    }
+                                }))
                             },
                             search(value) {
                                 if (value.length < this.minChars) {

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -156,7 +156,7 @@ class Choices extends Component
                                         : this.selection.push(id)
                                 }
 
-                                this.dispatchChangeEvent({ value: this.selection }, this.isSingle ? id : this.selection.join(','))    
+                                this.dispatchChangeEvent({ value: this.selection })    
 
                                 this.$refs.searchInput.value = ''
                                 this.$refs.searchInput.focus()
@@ -168,12 +168,8 @@ class Choices extends Component
 
                                 @this.{{ $searchFunction }}(value)
                             },
-                            dispatchChangeEvent(detail, inputOverride) {
-                                if (inputOverride) {
-                                    this.$refs.searchInput.value = inputOverride
-                                }
-
-                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change', { bubbles: true, detail }))
+                            dispatchChangeEvent(detail) {
+                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change-select', { bubbles: true, detail }))
                             }
                         }"
                     >

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -47,6 +47,11 @@ class Choices extends Component
         }
     }
 
+    public function onChangeFunc(): string | null
+    {
+        return $this->attributes->whereStartsWith('@change')->first();
+    }
+
     public function modelName(): string
     {
         return $this->attributes->wire('model')->value();
@@ -84,6 +89,10 @@ class Choices extends Component
                             isReadonly: {{ json_encode($isReadonly()) }},
                             isRequired: {{ json_encode($isRequired()) }},
                             minChars: {{ $minChars }},
+                            onChange: (id) => {
+                                $value = id;
+                                {{ $onChangeFunc() }}
+                            },
 
                             init() {
                                 // Fix weird issue when navigating back
@@ -153,6 +162,8 @@ class Choices extends Component
                                         ? this.selection = this.selection.filter(i => i != id)
                                         : this.selection.push(id)
                                 }
+
+                                this.onChange(this.selection)
 
                                 this.$refs.searchInput.value = ''
                                 this.$refs.searchInput.focus()

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -127,7 +127,7 @@ class Choices extends Component
                                     ? this.selection = null
                                     : this.selection = []
                                 
-                                this.dispatchChangeEvent({ value: null })
+                                this.dispatchChangeEvent({ value: this.isSingle ? null : []})
                             },
                             focus() {
                                 if (this.isReadonly) {

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -126,6 +126,8 @@ class Choices extends Component
                                 this.isSingle
                                     ? this.selection = null
                                     : this.selection = []
+                                
+                                this.dispatchChangeEvent({ value: null })
                             },
                             focus() {
                                 if (this.isReadonly) {
@@ -154,15 +156,10 @@ class Choices extends Component
                                         : this.selection.push(id)
                                 }
 
+                                this.dispatchChangeEvent({ value: this.selection }, this.isSingle ? id : this.selection.join(','))    
+
                                 this.$refs.searchInput.value = ''
                                 this.$refs.searchInput.focus()
-                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change', {
-                                    bubbles: true, 
-                                    detail: {
-                                        target: this.$refs.searchInput,
-                                        value: this.selection
-                                    }
-                                }))
                             },
                             search(value) {
                                 if (value.length < this.minChars) {
@@ -170,6 +167,13 @@ class Choices extends Component
                                 }
 
                                 @this.{{ $searchFunction }}(value)
+                            },
+                            dispatchChangeEvent(detail, inputOverride) {
+                                if (inputOverride) {
+                                    this.$refs.searchInput.value = inputOverride
+                                }
+
+                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change', { bubbles: true, detail }))
                             }
                         }"
                     >

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -169,7 +169,7 @@ class Choices extends Component
                                 @this.{{ $searchFunction }}(value)
                             },
                             dispatchChangeEvent(detail) {
-                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change-select', { bubbles: true, detail }))
+                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change-selection', { bubbles: true, detail }))
                             }
                         }"
                     >

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -118,6 +118,8 @@ class ChoicesOffline extends Component
                                 this.isSingle
                                     ? this.selection = null
                                     : this.selection = []
+
+                                this.dispatchChangeEvent({ value: this.selection })  
                             },
                             focus() {
                                 if (this.isReadonly) {
@@ -147,6 +149,7 @@ class ChoicesOffline extends Component
                                         : this.selection.push(id)
                                 }
 
+                                this.dispatchChangeEvent({ value: this.selection })  
                                 this.$refs.searchInput.focus()
                             },
                             lookup() {
@@ -160,6 +163,9 @@ class ChoicesOffline extends Component
 
                                 this.noResults = Array.from(this.$refs.choicesOptions.querySelectorAll('div > .hidden')).length ==
                                                  Array.from(this.$refs.choicesOptions.querySelectorAll('[search-value]')).length
+                            },
+                            dispatchChangeEvent(detail) {
+                                this.$refs.searchInput.dispatchEvent(new CustomEvent('change-selection', { bubbles: true, detail }))
                             }
                         }"
                     >


### PR DESCRIPTION
It would be good if the choices component issued an on change event similar to other inputs and selects. I added the capability for the user to use their own @change directive on the component. This is passed into the $attributes iterable and there is an added function called onChangeFunc that will return the value passed. Then, in the html rendered, onChange is set up in x-data as an anonymous function that wraps around the passed value. This protects the other rendered code. When toggle is called, the onchange function is triggered. The anonymous function is passed the value of selection and this is exposed to the user as a $value variable, which they can do cool stuff with, like emit an event or something. This has been tested in both single and multi choice components. It works well and does not break any other functionality according to my tests.

<hr />

![image](https://github.com/robsontenorio/mary/assets/118955/716d302f-ab1e-47ef-8610-ae3bfca77b50)
