### PR TITLE
Table: loop and decoration

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -13,6 +13,8 @@ class Table extends Component
 {
     public string $uuid;
 
+    public mixed $loop = null;
+
     public function __construct(
         public array $headers,
         public ArrayAccess|array $rows,
@@ -69,7 +71,7 @@ class Table extends Component
     // Handle header sort
     public function getSort(mixed $header): mixed
     {
-        if (!$this->isSortable($header)) {
+        if (! $this->isSortable($header)) {
             return false;
         }
 
@@ -185,6 +187,11 @@ class Table extends Component
                         <!-- ROWS -->
                         <tbody>
                             @foreach($rows as $k => $row)
+                                @php
+                                    # helper variable to provide the loop context
+                                    $this->loop = $loop;
+                                @endphp
+
                                 <tr wire:key="{{ $uuid }}-{{ $k }}" class="hover:bg-base-200/50" @click="$dispatch('row-click', {{ json_encode($row) }});">
 
                                     <!-- CHECKBOX -->

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -37,12 +37,24 @@ class Table extends Component
         public mixed $cell = null,
         public mixed $expansion = null
     ) {
-        //$this->uuid = "mary" . md5(serialize($this));
-        $this->uuid = rand();
-
         if ($this->selectable && $this->expandable) {
             throw new Exception("You can not combine `expandable` with `selectable`.");
         }
+
+        // Temp decoration
+        $rowDecoration = $this->rowDecoration;
+        $cellDecoration = $this->cellDecoration;
+
+        // Remove decoration from serialization, because they are closures.
+        unset($this->rowDecoration);
+        unset($this->cellDecoration);
+
+        // Serialize
+        $this->uuid = "mary" . md5(serialize($this));
+
+        // Put them back
+        $this->rowDecoration = $rowDecoration;
+        $this->cellDecoration = $cellDecoration;
     }
 
     // Get all ids for selectable and expandable features

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -131,11 +131,11 @@ class Table extends Component
         return Arr::join($classes, ' ');
     }
 
-    public function cellClasses(mixed $row, ?string $key): ?string
+    public function cellClasses(mixed $row, array $header): ?string
     {
-        $classes = [];
+        $classes = Str::of($header['class'] ?? '')->explode(' ')->all();
 
-        foreach ($this->cellDecoration[$key] ?? [] as $class => $condition) {
+        foreach ($this->cellDecoration[$header['key']] ?? [] as $class => $condition) {
             if ($condition($row)) {
                 $classes[] = $class;
             }
@@ -268,7 +268,7 @@ class Table extends Component
 
                                         <!--  HAS CUSTOM SLOT ? -->
                                         @if(isset(${"cell_".$temp_key}))
-                                            <td @class(["p-0" => $link])>
+                                            <td @class([$cellClasses($row, $header), "p-0" => $link])>
                                                 @if($link)
                                                     <a href="{{ $redirectLink($row) }}" wire:navigate class="block p-4">
                                                 @endif
@@ -280,8 +280,7 @@ class Table extends Component
                                                  @endif
                                             </td>
                                         @else
-                                            <td @class([$cellClasses($row, $header['key']), "p-0" => $link, "hidden" => Str::contains($header['class'] ?? '', 'hidden') ])>
-
+                                            <td @class([$cellClasses($row, $header), "p-0" => $link])>
                                                 @if($link)
                                                     <a href="{{ $redirectLink($row) }}" wire:navigate class="block p-4">
                                                 @endif

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -234,7 +234,7 @@ class Table extends Component
                                     $this->loop = $loop;
                                 @endphp
 
-                                <tr wire:key="{{ $uuid }}-{{ $k }}" class="hover:bg-base-200/50 opacity-100 {{ $rowClasses($row) }}" @click="$dispatch('row-click', {{ json_encode($row) }});">
+                                <tr wire:key="{{ $uuid }}-{{ $k }}" class="hover:bg-base-200/50 {{ $rowClasses($row) }}" @click="$dispatch('row-click', {{ json_encode($row) }});">
                                     <!-- CHECKBOX -->
                                     @if($selectable)
                                         <td class="w-1">


### PR DESCRIPTION
- Allow to access the `$loop` context.
- Add row and cell decoration properties.

How to test

```zsh
composer require robsontenorio/mary:dev-table-loopcontext
php artisan view:clear.
```


<img width="759" alt="image" src="https://github.com/robsontenorio/mary/assets/118955/b42a0e46-68d5-40f8-870f-52362598838b">

<img width="727" alt="image" src="https://github.com/robsontenorio/mary/assets/118955/04215c2a-d5ac-4941-b869-83b238f3fba9">

![image](https://github.com/robsontenorio/mary/assets/118955/2f041033-cec5-478c-b0e3-e99722eea893)


![image](https://github.com/robsontenorio/mary/assets/118955/e584bf20-cef5-4faf-beda-6bf381524c82)

![image](https://github.com/robsontenorio/mary/assets/118955/af0ecfc6-3bf1-4f47-ad3c-cb826561d582)

![image](https://github.com/robsontenorio/mary/assets/118955/0fcb81ff-6e1b-4fdc-811a-b6aac1141aa5)
