### PR TITLE
Accordion/Collapse: New components 

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Mary\Console\Commands\MaryBootcampCommand;
 use Mary\Console\Commands\MaryInstallCommand;
+use Mary\View\Components\Accordion;
 use Mary\View\Components\Alert;
 use Mary\View\Components\Avatar;
 use Mary\View\Components\Badge;
@@ -17,6 +18,7 @@ use Mary\View\Components\Chart;
 use Mary\View\Components\Checkbox;
 use Mary\View\Components\Choices;
 use Mary\View\Components\ChoicesOffline;
+use Mary\View\Components\Collapse;
 use Mary\View\Components\DatePicker;
 use Mary\View\Components\DateTime;
 use Mary\View\Components\Diff;
@@ -98,6 +100,7 @@ class MaryServiceProvider extends ServiceProvider
         $prefix = config('mary.prefix');
 
         // Blade
+        Blade::component($prefix . 'accordion', Accordion::class);
         Blade::component($prefix . 'alert', Alert::class);
         Blade::component($prefix . 'avatar', Avatar::class);
         Blade::component($prefix . 'badge', Badge::class);
@@ -108,6 +111,7 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'checkbox', Checkbox::class);
         Blade::component($prefix . 'choices', Choices::class);
         Blade::component($prefix . 'choices-offline', ChoicesOffline::class);
+        Blade::component($prefix . 'collapse', Collapse::class);
         Blade::component($prefix . 'datepicker', DatePicker::class);
         Blade::component($prefix . 'datetime', DateTime::class);
         Blade::component($prefix . 'diff', Diff::class);

--- a/src/View/Components/Accordion.php
+++ b/src/View/Components/Accordion.php
@@ -21,8 +21,8 @@ class Accordion extends Component
         return <<<'HTML'
                 <div
                     x-data="{ model: @entangle($attributes->wire('model')) }"
-                    {{ $attributes->merge(['class' => ($noJoin ? '' : 'join join-vertical w-full')]) }}
-                    wire:key="{{ $uuid }}"
+                    {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => ($noJoin ? '' : 'join join-vertical w-full')]) }}
+                    wire:key="accordion-{{ $uuid }}"
                 >
                         {{ $slot }}
                 </div>

--- a/src/View/Components/Accordion.php
+++ b/src/View/Components/Accordion.php
@@ -11,9 +11,7 @@ class Accordion extends Component
     public string $uuid;
 
     public function __construct(
-        public ?bool $join = false,
-
-    public mixed $actions = null
+        public ?bool $noJoin = false,
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
@@ -22,9 +20,10 @@ class Accordion extends Component
     {
         return <<<'HTML'
                 <div
-                    x-data="{ join: {{ $join ? 'true' : 'false' }} }"
-                    {{ $attributes->merge(['class' => ($join ? 'join join-vertical w-full' : '')]) }}
-                    wire:key="{{ $uuid }}">
+                    x-data="{ model: @entangle($attributes->wire('model')) }"
+                    {{ $attributes->merge(['class' => ($noJoin ? '' : 'join join-vertical w-full')]) }}
+                    wire:key="{{ $uuid }}"
+                >
                         {{ $slot }}
                 </div>
             HTML;

--- a/src/View/Components/Accordion.php
+++ b/src/View/Components/Accordion.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Mary\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Accordion extends Component
+{
+    public string $uuid;
+
+    public function __construct(
+        public ?bool $join = false,
+
+    public mixed $actions = null
+    ) {
+        $this->uuid = "mary" . md5(serialize($this));
+    }
+
+    public function render(): View|Closure|string
+    {
+        return <<<'HTML'
+                <div
+                    x-data="{ join: {{ $join ? 'true' : 'false' }} }"
+                    {{ $attributes->merge(['class' => ($join ? 'join join-vertical w-full' : '')]) }}
+                    wire:key="{{ $uuid }}">
+                        {{ $slot }}
+                </div>
+            HTML;
+    }
+}

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -12,7 +12,6 @@ class Collapse extends Component
 
     public function __construct(
         public ?string $name = null,
-        public ?bool $collapseArrow = true,
         public ?bool $collapsePlusMinus = false,
         public ?bool $separator = false,
 
@@ -30,7 +29,7 @@ class Collapse extends Component
 
                 <div
                     {{ $attributes->merge(['class' => 'collapse border border-base-300']) }}
-                    :class="{'join-item': '{{ ! $noJoin }}', 'collapse-arrow': '{{ $collapseArrow && ! $collapsePlusMinus }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
+                    :class="{'join-item': '{{ ! $noJoin }}', 'collapse-arrow': '{{ ! $collapsePlusMinus }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
                     wire:key="collapse-{{ $uuid }}"
                 >
                         <!-- Detects if it is inside an accordion.  -->

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -31,7 +31,7 @@ class Collapse extends Component
                 <div
                     {{ $attributes->merge(['class' => 'collapse border border-base-300']) }}
                     :class="{'join-item': '{{ ! $noJoin }}', 'collapse-arrow': '{{ $collapseArrow && ! $collapsePlusMinus }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
-                    wire:key="{{ $uuid }}"
+                    wire:key="collapse-{{ $uuid }}"
                 >
                         <!-- Detects if it is inside an accordion.  -->
                         @if(isset($noJoin))
@@ -43,7 +43,7 @@ class Collapse extends Component
                         <div {{ $heading->attributes->merge(["class" => "collapse-title text-xl font-medium"])  }}>
                             {{ $heading }}
                         </div>
-                        <div {{ $content->attributes->merge(["class" => "collapse-content"]) }}>
+                        <div {{ $content->attributes->merge(["class" => "collapse-content"]) }} wire:key="content-{{ $uuid }}">
                             @if($separator)
                                 <hr class="mb-3" />
                             @endif

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Mary\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Collapse extends Component
+{
+    public string $uuid;
+
+    public function __construct(
+        public ?string $name = null,
+        public ?bool $checked = false,
+        public ?bool $collapseArrow = false,
+        public ?bool $collapsePlusMinus = false,
+
+        // Slots
+        public mixed $heading = null,
+        public mixed $content = null,
+    public mixed $actions = null
+    ) {
+        $this->uuid = "mary" . md5(serialize($this));
+    }
+
+    public function render(): View|Closure|string
+    {
+        return <<<'HTML'
+                <div
+                    {{ $attributes->merge(['class' => 'collapse bg-base-200']) }}
+                    :class="{'join-item': join, 'collapse-arrow': '{{ $collapseArrow }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
+                    wire:key="{{ $uuid }}">
+                        <input type="radio" name="{{ $name }}" {{ $checked ? 'checked="checked"' : '' }}/>
+                        <div {{ $heading->attributes->merge(["class" => "collapse-title text-xl font-medium"])  }}>
+                            {{ $heading }}
+                        </div>
+                        <div {{ $content->attributes->merge(["class" => "collapse-content"])  }}>
+                            {{ $content }}
+                        </div>
+                </div>
+            HTML;
+    }
+}

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -12,15 +12,13 @@ class Collapse extends Component
 
     public function __construct(
         public ?string $name = null,
-        public ?bool $accordionItem = false,
-        public ?bool $checked = false,
-        public ?bool $collapseArrow = false,
+        public ?bool $collapseArrow = true,
         public ?bool $collapsePlusMinus = false,
+        public ?bool $separator = false,
 
         // Slots
         public mixed $heading = null,
         public mixed $content = null,
-    public mixed $actions = null
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
@@ -28,21 +26,28 @@ class Collapse extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div
-                    {{ $attributes->merge(['class' => 'collapse bg-base-200']) }}
-                    :class="{'join-item': join, 'collapse-arrow': '{{ $collapseArrow }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
-                    wire:key="{{ $uuid }}">
+                @aware(['noJoin' => null])
 
-                        @if($accordionItem)
-                            <input type="radio" name="{{ $name }}" {{ $checked ? 'checked="checked"' : '' }}/>
+                <div
+                    {{ $attributes->merge(['class' => 'collapse border border-base-300']) }}
+                    :class="{'join-item': '{{ ! $noJoin }}', 'collapse-arrow': '{{ $collapseArrow && ! $collapsePlusMinus }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
+                    wire:key="{{ $uuid }}"
+                >
+                        <!-- Detects if it is inside an accordion.  -->
+                        @if($noJoin)
+                            <input type="radio" value="{{ $name }}" x-model="model" />
                         @else
-                            <input type="checkbox" />
+                            <input {{ $attributes->wire('model') }} type="checkbox" />
                         @endif
 
                         <div {{ $heading->attributes->merge(["class" => "collapse-title text-xl font-medium"])  }}>
                             {{ $heading }}
                         </div>
-                        <div {{ $content->attributes->merge(["class" => "collapse-content"])  }}>
+                        <div {{ $content->attributes->merge(["class" => "collapse-content"]) }}>
+                            @if($separator)
+                                <hr class="mb-3" />
+                            @endif
+
                             {{ $content }}
                         </div>
                 </div>

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -12,6 +12,7 @@ class Collapse extends Component
 
     public function __construct(
         public ?string $name = null,
+        public ?bool $accordionItem = false,
         public ?bool $checked = false,
         public ?bool $collapseArrow = false,
         public ?bool $collapsePlusMinus = false,
@@ -31,7 +32,13 @@ class Collapse extends Component
                     {{ $attributes->merge(['class' => 'collapse bg-base-200']) }}
                     :class="{'join-item': join, 'collapse-arrow': '{{ $collapseArrow }}', 'collapse-plus': '{{ $collapsePlusMinus }}'}"
                     wire:key="{{ $uuid }}">
-                        <input type="radio" name="{{ $name }}" {{ $checked ? 'checked="checked"' : '' }}/>
+
+                        @if($accordionItem)
+                            <input type="radio" name="{{ $name }}" {{ $checked ? 'checked="checked"' : '' }}/>
+                        @else
+                            <input type="checkbox" />
+                        @endif
+
                         <div {{ $heading->attributes->merge(["class" => "collapse-title text-xl font-medium"])  }}>
                             {{ $heading }}
                         </div>

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -34,7 +34,7 @@ class Collapse extends Component
                     wire:key="{{ $uuid }}"
                 >
                         <!-- Detects if it is inside an accordion.  -->
-                        @if($noJoin)
+                        @if(isset($noJoin))
                             <input type="radio" value="{{ $name }}" x-model="model" />
                         @else
                             <input {{ $attributes->wire('model') }} type="checkbox" />


### PR DESCRIPTION

![image](https://github.com/robsontenorio/mary/assets/118955/e3489ede-0457-418f-8032-d550a2941b9a)

![image](https://github.com/robsontenorio/mary/assets/118955/087bd334-db97-4178-91b1-17ffe4bc0ccb)

![image](https://github.com/robsontenorio/mary/assets/118955/661b9a51-8a8c-4634-a095-8ac0a88bbebb)

![image](https://github.com/robsontenorio/mary/assets/118955/6f120e8a-7b91-4271-9465-44aff37b11b6)


# Note (from Daisy):
- Accordion uses the same style as the collapse component, but it works with radio inputs. You can control which item to be open by checking/unchecking the hidden radio input.
- All radio inputs with the same name work together and only one of them can be open at a time. If you have more than one set of accordion items on a page, use different names for the radio inputs on each set.


## Usage of Collapse:
```
<x-collapse>
    <x-slot:heading>
        Hello World
    </x-slot:heading>
    <x-slot:content>
        Lorem ipsum dolor sit amet, consectetur adipiscing elit
    </x-slot:content>
</x-collapse>
```
Options:
- **accordion-item**: (attr) Defines if the element is part of an accordion group.
- **name**: (attr="value") The name of the radio group if part of an accordion.
- **checked**: (attr) Whether the component is checked by default or not.
- **collapse-arrow**: (attr) Accordion with arrow icon.
- **collapse-plus-minus**: (attr) Accordion with plus/minus icon.


## Usage of Accordion:
```
<x-accordion join>
  <x-collapse name="test-1" collapse-plus-minus checked> // Notice the collapse-plus-minus & checked attribute
    <x-slot:heading>Test 1</x-slot:heading>
    <x-slot:content>
        <p>World Hello</p>
    </x-slot:content>
  </x-collapse>
  <x-collapse name="test-1" collapse-arrow> // Notice the collapse-arrow attribute
    <x-slot:heading class="!bg-blue-500">Test 2</x-slot:heading>
    <x-slot:content class="!bg-blue-500">
        <p>Hello World</p>
    </x-slot:content>
  </x-collapse>
</x-accordion>
```
Options:
- **join**: (attr) To join the items together and handle border radius automatically.
