### PR TITLE
Icon: add icon set config option

### DIFF
--- a/config/mary.php
+++ b/config/mary.php
@@ -24,7 +24,10 @@ return [
     'components' => [
         'spotlight' => [
             'class' => 'App\Support\Spotlight',
-        ]
-    ]
+        ],
+        'icon' => [
+            'set' => 'heroicon',
+        ],
+    ],
 ];
 

--- a/src/View/Components/Icon.php
+++ b/src/View/Components/Icon.php
@@ -22,7 +22,7 @@ class Icon extends Component
     {
         $name = Str::of($this->name);
 
-        return $name->contains('.') ? $name->replace('.', '-') : "heroicon-{$this->name}";
+        return $name->contains('.') ? $name->replace('.', '-') : "{config('mary.components.icon.set', 'heroicon')}-{$this->name}";
     }
 
     public function labelClasses(): ?string


### PR DESCRIPTION
Add support to adjust/replace the hardcoded `heroicon` inside the Icon component to allow dot-less naming for non heroicons