### PR TITLE
Input: flexible error bag key

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -22,6 +22,7 @@ class Input extends Component
         public ?bool $omitError = false,
         public ?bool $money = false,
         public ?string $locale = 'en-US',
+        public ?string $errorBag = null,
 
         // Slots
         public mixed $prepend = null,
@@ -33,6 +34,11 @@ class Input extends Component
     public function modelName(): ?string
     {
         return $this->attributes->whereStartsWith('wire:model')->first();
+    }
+
+    public function errorBagName(): ?string
+    {
+        return $this->errorBag ?? $this->modelName();
     }
 
     public function moneySettings(): string
@@ -80,7 +86,7 @@ class Input extends Component
                                 "border border-primary border-r-0 px-4" => $prefix,
                                 "border-0 bg-base-300" => $attributes->has('disabled') && $attributes->get('disabled') == true,
                                 "border-dashed" => $attributes->has('readonly') && $attributes->get('readonly') == true,
-                                "!border-error" => $modelName() && $errors->has($modelName()) && !$omitError
+                                "!border-error" => $errorBagName() && $errors->has($errorBagName()) && !$omitError
                             ])
                     >
                         {{ $prepend ?? $prefix }}
@@ -120,7 +126,7 @@ class Input extends Component
                                     'rounded-l-none' => $prefix || $prepend,
                                     'rounded-r-none' => $suffix || $append,
                                     'border border-dashed' => $attributes->has('readonly') && $attributes->get('readonly') == true,
-                                    'input-error' => $modelName() && $errors->has($modelName()) && !$omitError
+                                    'input-error' => $errorBagName() && $errors->has($errorBagName()) && !$omitError
                             ])
                         }}
                     />
@@ -162,7 +168,7 @@ class Input extends Component
                                 "border border-primary border-l-0 px-4" => $suffix,
                                 "border-0 bg-base-300" => $attributes->has('disabled') && $attributes->get('disabled') == true,
                                 "border-dashed" => $attributes->has('readonly') && $attributes->get('readonly') == true,
-                                "!border-error" => $modelName() && $errors->has($modelName()) && !$omitError
+                                "!border-error" => $errorBagName() && $errors->has($errorBagName()) && !$omitError
                             ])
                     >
                         {{ $append ?? $suffix }}
@@ -175,8 +181,8 @@ class Input extends Component
                 @endif
 
                 <!-- ERROR -->
-                @if(!$omitError && $modelName())
-                    @error($modelName())
+                @if(!$omitError && $errorBagName())
+                    @error($errorBagName())
                         <div class="text-red-500 label-text-alt p-1">{{ $message }}</div>
                     @enderror
                 @endif


### PR DESCRIPTION
This PR adds the ability to customise the key used in the error bag, this helps with compatibility with Jetstream and other packages. It is backwards compatible with current usage.

Usage Example
```html
 <x-mary-input label="{{ __('iam::profile.password.fields.new_password') }}"
                          type="password"
                          name="password"
                          wire:model="state.password"
                          autocomplete="new-password"
                          error-bag="password"
            />
```

If you look at how the Jetstream livewire component works, they have a state array which contains most of the fields. The result is the passed as an array to an action which can raise a standard Validation error. The end result of this is the key in the error bag does not have "state" in it, but the wire:model does.

It is preferable to just update the published view template that Jetstream uses, rather than having to modify the whole component.

```php
<?php

namespace Laravel\Jetstream\Http\Livewire;

use Illuminate\Support\Facades\Auth;
use Laravel\Fortify\Contracts\UpdatesUserPasswords;
use Livewire\Component;

class UpdatePasswordForm extends Component
{
    /**
     * The component's state.
     *
     * @var array
     */
    public $state = [
        'current_password' => '',
        'password' => '',
        'password_confirmation' => '',
    ];

    /**
     * Update the user's password.
     *
     * @param  \Laravel\Fortify\Contracts\UpdatesUserPasswords  $updater
     * @return void
     */
    public function updatePassword(UpdatesUserPasswords $updater)
    {
        $this->resetErrorBag();

        $updater->update(Auth::user(), $this->state);

        if (request()->hasSession()) {
            request()->session()->put([
                'password_hash_'.Auth::getDefaultDriver() => Auth::user()->getAuthPassword(),
            ]);
        }

        $this->state = [
            'current_password' => '',
            'password' => '',
            'password_confirmation' => '',
        ];

        $this->dispatch('saved');
    }

    /**
     * Get the current user of the application.
     *
     * @return mixed
     */
    public function getUserProperty()
    {
        return Auth::user();
    }

    /**
     * Render the component.
     *
     * @return \Illuminate\View\View
     */
    public function render()
    {
        return view('profile.update-password-form');
    }
}
```