### PR TITLE
MenuTitle: new component & MenuSeparator: remove title and set correct style 

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -43,6 +43,7 @@ use Mary\View\Components\Menu;
 use Mary\View\Components\MenuItem;
 use Mary\View\Components\MenuSeparator;
 use Mary\View\Components\MenuSub;
+use Mary\View\Components\MenuTitle;
 use Mary\View\Components\Modal;
 use Mary\View\Components\Nav;
 use Mary\View\Components\Progress;
@@ -139,6 +140,7 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'menu-item', MenuItem::class);
         Blade::component($prefix . 'menu-separator', MenuSeparator::class);
         Blade::component($prefix . 'menu-sub', MenuSub::class);
+        Blade::component($prefix . 'menu-title', MenuTitle::class);
         Blade::component($prefix . 'main', Main::class);
         Blade::component($prefix . 'nav', Nav::class);
         Blade::component($prefix . 'progress', Progress::class);

--- a/src/View/Components/MenuTitle.php
+++ b/src/View/Components/MenuTitle.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mary\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class MenuTitle extends Component
+{
+    public string $uuid;
+
+    public function __construct(
+        public ?string $title = null,
+        public ?string $icon = null,
+    ) {
+        $this->uuid = 'mary'.md5(serialize($this));
+    }
+
+    public function render(): View|Closure|string
+    {
+        return <<<'HTML'
+                <li {{ $attributes->class(["menu-title"]) }}>
+                    <div class="flex items-center gap-2">
+
+                        @if($icon)
+                            <x-mary-icon :name="$icon"  />
+                        @endif
+
+                        {{ $title }}
+                    </div>
+                </li>
+            HTML;
+    }
+}


### PR DESCRIPTION
I've added a new component MenuTitle & removed the title from MenuSeparator.

I've removed your default uppercase class to comply with daisyUI default style and it's hard to remove it if you don't want it (like me).

Example Images from maryUI-Docs - Left (modified) / Right (current)
![image](https://github.com/robsontenorio/mary/assets/1554582/9f7223cd-fd74-4ed7-b28e-2f6dc439b475) ![image](https://github.com/robsontenorio/mary/assets/1554582/ec0a3a21-ecb6-44a7-b105-414a9596cb8a)
![image](https://github.com/robsontenorio/mary/assets/1554582/6659007b-e251-4ce8-a863-a82a600841da) ![image](https://github.com/robsontenorio/mary/assets/1554582/34f5167c-a5ca-427a-b498-c0c8426a3013)

In my use-case it looks like that

Dropdown with a simple MenuTitle and a single MenuSeparator
![image](https://github.com/robsontenorio/mary/assets/1554582/1ea0a5fb-279e-433e-b897-19fe96521fbf)


P.S.: mary-ui.com change/PR is coming too ;) 