### PR TITLE
feat(choices): Allow passing arguments to search function

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -172,7 +172,7 @@ class Choices extends Component
                                     return
                                 }
 
-                                @this.{{ $searchFunction }}(value)
+                                @this.{{ str_replace(')(', ', ', $searchFunction . '(value)') }}
                             },
                             dispatchChangeEvent(detail) {
                                 this.$refs.searchInput.dispatchEvent(new CustomEvent('change-selection', { bubbles: true, detail }))
@@ -286,7 +286,7 @@ class Choices extends Component
                             <div wire:key="options-list-{{ $uuid }}" class="{{ $height }} w-full absolute z-10 shadow-xl bg-base-100 border border-base-300 rounded-lg cursor-pointer overflow-y-auto" x-anchor.bottom-start="$refs.container">
 
                                 <!-- PROGRESS -->
-                                <progress wire:loading wire:target="{{ $searchFunction }}" class="progress absolute progress-primary top-0 h-0.5"></progress>
+                                <progress wire:loading wire:target="{{ preg_replace('/\((.*?)\)/', '', $searchFunction) }}" class="progress absolute progress-primary top-0 h-0.5"></progress>
 
                                <!-- SELECT ALL -->
                                @if($allowAll)

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -172,7 +172,12 @@ class Choices extends Component
                                     return
                                 }
 
-                                @this.{{ str_replace(')(', ', ', $searchFunction . '(value)') }}
+                                // Call search function from parent component
+                                // `search(value)` or `search(value, extra1, extra2 ...)`
+                                @this.{{ str_contains($searchFunction, '(')
+                                          ? preg_replace('/\((.*?)\)/', '(value, $1)', $searchFunction)
+                                          : $searchFunction . '(value)'
+                                        }}
                             },
                             dispatchChangeEvent(detail) {
                                 this.$refs.searchInput.dispatchEvent(new CustomEvent('change-selection', { bubbles: true, detail }))


### PR DESCRIPTION
## Description

This pull request introduces the ability to pass additional arguments to the search function used within the `x-choices` component.

**Existing code with the original search-function behavior continues to work seamlessly.**

## Current Behavior:

The `x-choices` component currently allows specifying a search function name only. This function is called with only the search value as the argument.

## Proposed Change:

This PR modifies the x-choices component to accept additional arguments to be passed to the search function. This enables developers to provide more context to the search.

Example:

```html
<x-choices
    label="My choices component"
    wire:model="selectedItems"
    :options="options"
    search-function="search('{{$myValue}}', {{$someId}})"
    no-result-text="Nothing found!"
    searchable
/>
```

This will allow the parent component to handle it as:

```php
public function search(string $value, int $someId, string $search)
{
    // Implement your search logic using $value, $someId and $search arguments
}
```
