### PR TITLE
DarkMode: fix three bugs in components

### DIFF
--- a/src/View/Components/Hr.php
+++ b/src/View/Components/Hr.php
@@ -28,10 +28,10 @@ class Hr extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div class="h-[2px] border border-t-base-100 my-5">
+                <div class="h-[2px] border-t border-base-content/10 my-5">
                     <progress
-                        class="progress progress-primary hidden h-[1px]"
-                        wire:loading.class="!h-[2px] !block"
+                        class="progress progress-primary hidden -mt-[1.5px] !h-[2px]"
+                        wire:loading.class="!block"
 
                         @if($progressTarget())
                             wire:target="{{ $progressTarget() }}"

--- a/src/View/Components/Nav.php
+++ b/src/View/Components/Nav.php
@@ -22,7 +22,7 @@ class Nav extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                    <div {{ $attributes->class(["bg-base-100 border-gray-100 border-b", "sticky top-0 z-10" => $sticky]) }}>
+                    <div {{ $attributes->class(["bg-base-100 border-base-300 border-b", "sticky top-0 z-10" => $sticky]) }}>
                         <div @class(["flex items-center px-6 py-5",  "max-w-screen-2xl mx-auto" => !$fullWidth])>
                             <div {{ $brand?->attributes->class(["flex-1 flex items-center"]) }}>
                                 {{ $brand }}


### PR DESCRIPTION
I've fixed three dark mode bugs.

- Hr: reflect daisyUI's divider style 
- Nav: update border-color to work good light and dark 
- ThemeToggle: fix initial theme setter from 3 possible sources
  also fixed in this commit:
  - replaced setAttribute on class to classList add/remove to avoid html class reset/override
  - fix usage of theme-controller to avoid wrong switching
  - add missing focus outline if ThemeToggle has class `btn` set

Let me know if you want some screenshots to compare the before and after.