### PR TITLE
Custom modal size

### DIFF
--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -12,7 +12,7 @@ class Modal extends Component
         public ?string $id = '',
         public ?string $title = null,
         public ?string $subtitle = null,
-        public ?string $class = null,
+        public ?string $boxClass = null,
         public ?bool $separator = false,
         public ?bool $persistent = false,
 
@@ -39,7 +39,7 @@ class Modal extends Component
                         @endif
                     @endif
                 >
-                    <div class="modal-box {{ $class }}">
+                    <div class="modal-box {{ $boxClass }}">
                         @if($title)
                             <x-mary-header :title="$title" :subtitle="$subtitle" size="text-2xl" :separator="$separator" class="mb-5" />
                         @endif

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -12,7 +12,7 @@ class Modal extends Component
         public ?string $id = '',
         public ?string $title = null,
         public ?string $subtitle = null,
-        public ?string $boxClass = null,
+        public ?string $class = null,
         public ?bool $separator = false,
         public ?bool $persistent = false,
 
@@ -39,7 +39,7 @@ class Modal extends Component
                         @endif
                     @endif
                 >
-                    <div class="modal-box {{ $boxClass }}">
+                    <div class="modal-box {{ $class }}">
                         @if($title)
                             <x-mary-header :title="$title" :subtitle="$subtitle" size="text-2xl" :separator="$separator" class="mb-5" />
                         @endif

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -12,6 +12,7 @@ class Modal extends Component
         public ?string $id = '',
         public ?string $title = null,
         public ?string $subtitle = null,
+        public ?string $boxClass = null,
         public ?bool $separator = false,
         public ?bool $persistent = false,
 
@@ -38,7 +39,7 @@ class Modal extends Component
                         @endif
                     @endif
                 >
-                    <div class="modal-box">
+                    <div class="modal-box {{ $boxClass }}">
                         @if($title)
                             <x-mary-header :title="$title" :subtitle="$subtitle" size="text-2xl" :separator="$separator" class="mb-5" />
                         @endif


### PR DESCRIPTION
I've added a `class` attribute to add custom classes to the `modal-box` div (#358)

Usage for custom modal size:
```html
<x-modal wire:model="myModal1" class="w-11/12 max-w-5xl">
    <div class="mb-5">Press `ESC`, click outside or click `CANCEL` to close.</div>
    <x-button label="Cancel" @click="$wire.myModal1 = false" />
</x-modal>
```