### PR TITLE
Menu item route param, default theme based on system preferences

### DIFF
--- a/src/View/Components/Main.php
+++ b/src/View/Components/Main.php
@@ -62,7 +62,7 @@ class Main extends Component
                                             "flex flex-col !transition-all !duration-100 ease-out overflow-x-hidden overflow-y-auto h-screen",
                                             "w-[70px] [&>*_summary::after]:hidden [&_.mary-hideable]:hidden [&_.display-when-collapsed]:block [&_.hidden-when-collapsed]:hidden" => session('mary-sidebar-collapsed') == 'true',
                                             "w-[270px] [&>*_summary::after]:block [&_.mary-hideable]:block [&_.hidden-when-collapsed]:block [&_.display-when-collapsed]:hidden" => session('mary-sidebar-collapsed') != 'true',
-                                            "pb-[73px]" => $withNav
+                                            "lg:h-[calc(100vh-73px)]" => $withNav
                                         ])
                                      }}
                                 >

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -16,6 +16,7 @@ class MenuItem extends Component
         public ?string $title = null,
         public ?string $icon = null,
         public ?string $link = null,
+        public ?string $route = null,
         public ?bool $external = false,
         public ?bool $noWireNavigate = false,
         public ?string $badge = null,
@@ -30,6 +31,10 @@ class MenuItem extends Component
     {
         if ($this->link == null) {
             return false;
+        }
+
+        if ($this->route) {
+            return request()->routeIs($this->route);
         }
 
         $link = url($this->link ?? '');

--- a/src/View/Components/ThemeToggle.php
+++ b/src/View/Components/ThemeToggle.php
@@ -26,7 +26,7 @@ class ThemeToggle extends Component
                 <div>
                     <label
                         x-data="{
-                            theme: $persist('light').as('mary-theme'),
+                            theme: $persist(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light').as('mary-theme'),
                             init() {
                                 if (this.theme == 'dark') {
                                     this.$refs.sun.classList.add('swap-off');
@@ -34,12 +34,16 @@ class ThemeToggle extends Component
                                     this.$refs.moon.classList.add('swap-on');
                                     this.$refs.moon.classList.remove('swap-off');
                                 }
+                                this.setToggle()
                             },
-                            toggle() {
-                                this.theme = this.theme == 'light' ? 'dark' : 'light'
+                            setToggle() {
                                 document.documentElement.setAttribute('data-theme', this.theme)
                                 document.documentElement.setAttribute('class', this.theme)
                                 this.$dispatch('theme-changed', this.theme)
+                            },
+                            toggle() {
+                                this.theme = this.theme == 'light' ? 'dark' : 'light'
+                                this.setToggle()
                             }
                         }"
                         @mary-toggle-theme.window="toggle()"


### PR DESCRIPTION
Hi!

I added default theme based on system preferences on alpine present plugin.
Don't why there is 2 params as $light and $dark that i don't see used anywhere.

For route param, this simply fixes my use case, where i have whole user panel under same prefix, and it makes few menu items active at the same time, simply using laravel based request()->routeIs() with * sign you can make only few route available.

Third thing is that i changed classes for sidebar to make it without scroll on sidebar. That the only thing that I'm not 100% sure of. But from my testing everything works great, even with bigger menus.
