### PR TITLE
feat: add `sunday-start` modifier

### DIFF
--- a/src/View/Components/Calendar.php
+++ b/src/View/Components/Calendar.php
@@ -16,6 +16,7 @@ class Calendar extends Component
         public ?int $months = 1,
         public ?string $locale = 'en-EN',
         public ?bool $weekendHighlight = false,
+        public ?bool $sundayStart = false,
         public ?array $config = [],
         public ?array $events = [],
     ) {
@@ -38,6 +39,7 @@ class Calendar extends Component
                 'selection' => [
                     'day' => false,
                 ],
+                'iso8601' => !$this->sundayStart,
             ],
             'CSSClasses' => 'y',
             'actions' => 'x',


### PR DESCRIPTION
This allows a cleaner way to make the calendar start on Sunday.

Currently to display make the calendar start on Sunday you have to do this
```blade
<x-mary-calendar locale="en-PH" :events="$events" weekend-highlight :config="['settings' => ['iso8601' => false]]" />
```
which IMO pretty verbose for a simple modification.