### PR TITLE
feat: hide 'X' button if no selection is made

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -126,7 +126,7 @@ class Choices extends Component
                             },
                             get isSelectionEmpty() {
                                 return this.isSingle
-                                    ? this.selection == null
+                                    ? this.selection == null || this.selection == ''
                                     : this.selection.length == 0
                             },
                             selectAll() {
@@ -241,7 +241,7 @@ class Choices extends Component
 
                             <!-- CLEAR ICON  -->
                             @if(! $isReadonly() && ! $isDisabled())
-                                <x-mary-icon @click="reset()"  name="o-x-mark" class="absolute top-1/2 right-8 -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-600" />
+                                <x-mary-icon @click="reset()"  name="o-x-mark" x-show="!isSelectionEmpty" class="absolute top-1/2 right-8 -translate-y-1/2 cursor-pointer text-gray-400 hover:text-gray-600" />
                             @endif
 
                             <!-- SELECTED OPTIONS -->


### PR DESCRIPTION
This utilizes the existing getter `isSelectionEmpty` and tweaking it a bit to treat an empty string as empty. The hiding of the 'X' button is done with the x-show attribute.

implements #426