### PR TITLE
Draft: Add label's `for` attribute and missing  `ids`

### DIFF
--- a/src/View/Components/Checkbox.php
+++ b/src/View/Components/Checkbox.php
@@ -8,6 +8,7 @@ use Illuminate\View\Component;
 
 class Checkbox extends Component
 {
+    public string $uuid;
 
     public function __construct(
         public ?string $label = null,
@@ -19,8 +20,8 @@ class Checkbox extends Component
         public ?string $errorClass = 'text-red-500 label-text-alt p-1',
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
-    )
-    {
+    ) {
+        $this->uuid = "mary" . md5(serialize($this));
     }
 
     public function modelName(): ?string
@@ -37,14 +38,17 @@ class Checkbox extends Component
     {
         return <<<'HTML'
                 <div>
-                    <label class="flex gap-3 items-center cursor-pointer">
+                    <label for="{{ $uuid }}" class="flex gap-3 items-center cursor-pointer">
                         @if($right)
                             <span @class(["flex-1" => !$tight])>
                                 {{ $label}}
                             </span>
                         @endif
 
-                        <input type="checkbox" {{ $attributes->whereDoesntStartWith('class') }} {{ $attributes->class(['checkbox checkbox-primary']) }}  />
+                        <input
+                            type="checkbox"
+                            {{ $attributes->whereDoesntStartWith('class') }}
+                            {{ $attributes->merge(["id" => $uuid])->class(['checkbox checkbox-primary']) }}  />
 
                         @if(!$right)
                             {{ $label}}

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -195,7 +195,7 @@ class Choices extends Component
                     >
                         <!-- STANDARD LABEL -->
                         @if($label)
-                            <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                            <div class="pt-0 label label-text font-semibold">
                                 <span>
                                     {{ $label }}
 
@@ -203,7 +203,7 @@ class Choices extends Component
                                         <span class="text-error">*</span>
                                     @endif
                                 </span>
-                            </label>
+                            </div>
                         @endif
 
                         <!-- PREPEND/APPEND CONTAINER -->
@@ -270,6 +270,7 @@ class Choices extends Component
 
                             <!-- INPUT SEARCH -->
                             <input
+                                id="{{ $uuid }}"
                                 x-ref="searchInput"
                                 @input="focus()"
                                 :required="isRequired && isSelectionEmpty"

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -195,7 +195,7 @@ class Choices extends Component
                     >
                         <!-- STANDARD LABEL -->
                         @if($label)
-                            <div class="pt-0 label label-text font-semibold">
+                            <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
                                 <span>
                                     {{ $label }}
 
@@ -203,7 +203,7 @@ class Choices extends Component
                                         <span class="text-error">*</span>
                                     @endif
                                 </span>
-                            </div>
+                            </label>
                         @endif
 
                         <!-- PREPEND/APPEND CONTAINER -->

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -186,7 +186,7 @@ class ChoicesOffline extends Component
                     >
                         <!-- STANDARD LABEL -->
                         @if($label)
-                            <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                            <div class="pt-0 label label-text font-semibold">
                                 <span>
                                     {{ $label }}
 
@@ -194,7 +194,7 @@ class ChoicesOffline extends Component
                                         <span class="text-error">*</span>
                                     @endif
                                 </span>
-                            </label>
+                            </div>
                         @endif
 
                         <!-- PREPEND/APPEND CONTAINER -->
@@ -261,6 +261,7 @@ class ChoicesOffline extends Component
 
                             <!-- INPUT SEARCH -->
                             <input
+                                id="{{ $uuid }}"
                                 x-ref="searchInput"
                                 x-model="search"
                                 @keyup="lookup()"

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -186,7 +186,7 @@ class ChoicesOffline extends Component
                     >
                         <!-- STANDARD LABEL -->
                         @if($label)
-                            <div class="pt-0 label label-text font-semibold">
+                            <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
                                 <span>
                                     {{ $label }}
 
@@ -194,7 +194,7 @@ class ChoicesOffline extends Component
                                         <span class="text-error">*</span>
                                     @endif
                                 </span>
-                            </div>
+                            </label>
                         @endif
 
                         <!-- PREPEND/APPEND CONTAINER -->

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -42,9 +42,9 @@ class Collapse extends Component
                 >
                         <!-- Detects if it is inside an accordion.  -->
                         @if(isset($noJoin))
-                            <input type="radio" value="{{ $name }}" x-model="model" />
+                            <input id="radio-{{ $uuid }}" type="radio" value="{{ $name }}" x-model="model" />
                         @else
-                            <input {{ $attributes->wire('model') }} type="checkbox" />
+                            <input id="checkbox-{{ $uuid }}" {{ $attributes->wire('model') }} type="checkbox" />
                         @endif
 
                         <div

--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -93,7 +93,7 @@ class DatePicker extends Component
                                         ->merge(['type' => 'date'])
                                         ->class([
                                             "input input-primary w-full peer appearance-none",
-                                            'pl-10' => ($icon),
+                                            'ps-10' => ($icon),
                                             'h-14' => ($inline),
                                             'pt-3' => ($inline && $label),
                                             'border border-dashed' => $attributes->has('readonly') && $attributes->get('readonly') == true,
@@ -115,7 +115,7 @@ class DatePicker extends Component
 
                     <!-- INLINE LABEL -->
                     @if($label && $inline)
-                        <div class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                        <div class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) start-9 @else start-3 @endif">
                             {{ $label }}
                         </div>
                     @endif

--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -58,7 +58,7 @@ class DatePicker extends Component
         $config = str_replace('"#plugins#"', $plugins, $config);
 
         // Sets default date as current bound model
-        $config = str_replace('"#model#"', '$wire.get("' . $this->modelName().'")', $config);
+        $config = str_replace('"#model#"', '$wire.get("' . $this->modelName() . '")', $config);
 
         return $config;
     }
@@ -69,7 +69,7 @@ class DatePicker extends Component
             <div wire:key="datepicker-{{ rand() }}">
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
-                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <div class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -77,7 +77,7 @@ class DatePicker extends Component
                                 <span class="text-error">*</span>
                             @endif
                         </span>
-                    </label>
+                    </div>
                 @endif
 
                 <div class="flex-1 relative">
@@ -115,9 +115,9 @@ class DatePicker extends Component
 
                     <!-- INLINE LABEL -->
                     @if($label && $inline)
-                        <label for="{{ $uuid }}" class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
+                        <div class="absolute text-gray-400 duration-300 transform -translate-y-1 scale-75 top-2 origin-[0] rounded px-2 peer-focus:px-2 peer-focus:text-blue-600 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-1 @if($inline && $icon) left-9 @else left-3 @endif">
                             {{ $label }}
-                        </label>
+                        </div>
                     @endif
 
                 </div>

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -9,6 +9,7 @@ use Illuminate\View\Component;
 class Editor extends Component
 {
     public string $uuid;
+
     public string $uploadUrl;
 
     public function __construct(
@@ -62,7 +63,7 @@ class Editor extends Component
                 <div>
                     <!-- STANDARD LABEL -->
                     @if($label)
-                        <div for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                        <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
                             <span>
                                 {{ $label }}
 
@@ -70,7 +71,7 @@ class Editor extends Component
                                     <span class="text-error">*</span>
                                 @endif
                             </span>
-                        </div>
+                        </label>
                     @endif
 
                     <!--  EDITOR  -->
@@ -123,7 +124,7 @@ class Editor extends Component
                         x-on:livewire:navigating.window="tinymce.activeEditor.destroy();"
                         wire:ignore
                     >
-                        <input x-ref="tinymce" type="textarea" {{ $attributes->whereDoesntStartWith('wire:model') }} />
+                        <input id="{{ $uuid }}" x-ref="tinymce" type="textarea" {{ $attributes->whereDoesntStartWith('wire:model') }} />
                     </div>
 
                     <!-- ERROR -->

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -60,7 +60,7 @@ class Editor extends Component
                 <div>
                     <!-- STANDARD LABEL -->
                     @if($label)
-                        <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                        <div for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
                             <span>
                                 {{ $label }}
 
@@ -68,7 +68,7 @@ class Editor extends Component
                                     <span class="text-error">*</span>
                                 @endif
                             </span>
-                        </label>
+                        </div>
                     @endif
 
                     <!--  EDITOR  -->

--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -134,7 +134,7 @@ class ImageLibrary extends Component
                 >
                     <!-- STANDARD LABEL -->
                     @if($label)
-                        <label class="pt-0 label label-text font-semibold">{{ $label }}</label>
+                        <div class="pt-0 label label-text font-semibold">{{ $label }}</div>
                     @endif
 
                     <!-- PREVIEW AREA -->

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -66,7 +66,7 @@ class Markdown extends Component
             <div>
                 <!-- STANDARD LABEL -->
                 @if($label)
-                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <div for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -74,7 +74,7 @@ class Markdown extends Component
                                 <span class="text-error">*</span>
                             @endif
                         </span>
-                    </label>
+                    </div>
                 @endif
 
                 <!-- EDITOR -->
@@ -135,7 +135,7 @@ class Markdown extends Component
                         @break($firstErrorOnly)
                     @endforeach
                 @endif
-                
+
             </div>
             HTML;
     }

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -9,6 +9,7 @@ use Illuminate\View\Component;
 class Markdown extends Component
 {
     public string $uuid;
+
     public string $uploadUrl;
 
     public function __construct(
@@ -68,7 +69,7 @@ class Markdown extends Component
             <div>
                 <!-- STANDARD LABEL -->
                 @if($label)
-                    <div for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                    <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
                         <span>
                             {{ $label }}
 
@@ -76,7 +77,7 @@ class Markdown extends Component
                                 <span class="text-error">*</span>
                             @endif
                         </span>
-                    </div>
+                    </label>
                 @endif
 
                 <!-- EDITOR -->
@@ -117,7 +118,7 @@ class Markdown extends Component
                     x-on:livewire:navigating.window="editor.toTextArea(); editor = null"
                 >
                     <div class="relative disabled" :class="uploading && 'pointer-events-none opacity-50'">
-                        <textarea x-ref="markdown{{ $uuid }}"></textarea>
+                        <textarea id="{{ $uuid }}" x-ref="markdown{{ $uuid }}"></textarea>
 
                         <div class="absolute top-1/2 start-1/2 !opacity-100 text-center hidden" :class="uploading && '!block'">
                             <div>Uploading</div>

--- a/src/View/Components/Pin.php
+++ b/src/View/Components/Pin.php
@@ -77,6 +77,7 @@ class Pin extends Component
                         <div class="flex gap-3" id="pin{{ $uuid }}">
                             @foreach(range(0, $size - 1) as $i)
                                 <input
+                                    id="{{ $uuid }}-pin-{{ $i }}"
                                     type="text"
                                     class="input input-primary !w-14 font-black text-2xl text-center"
                                     maxlength="1"

--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -9,7 +9,6 @@ use Illuminate\View\Component;
 
 class Radio extends Component
 {
-
     public string $uuid;
 
     public function __construct(
@@ -42,7 +41,7 @@ class Radio extends Component
         return <<<'HTML'
                 <div>
                     @if($label)
-                        <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
+                        <div class="pt-0 label label-text font-semibold">
                             <span>
                                 {{ $label }}
 
@@ -50,7 +49,7 @@ class Radio extends Component
                                     <span class="text-error">*</span>
                                 @endif
                             </span>
-                        </label>
+                        </div>
                     @endif
 
                     <div class="join">

--- a/src/View/Components/Range.php
+++ b/src/View/Components/Range.php
@@ -3,12 +3,11 @@
 namespace Mary\View\Components;
 
 use Closure;
-use Illuminate\View\Component;
 use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
 
 class Range extends Component
 {
-
     public string $uuid;
 
     public function __construct(
@@ -21,8 +20,7 @@ class Range extends Component
         public ?string $errorClass = 'text-red-500 label-text-alt p-1',
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
-    )
-    {
+    ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
 
@@ -58,7 +56,7 @@ class Range extends Component
                         type="range"
                         min="{{ $min }}"
                         max="{{ $max }}"
-                        {{ $attributes->merge(["class" => "range"])->except('label', 'hint', 'min', 'max') }}
+                        {{ $attributes->merge(["class" => "range", "id" => $uuid])->except('label', 'hint', 'min', 'max') }}
                     />
 
                     <!-- ERROR -->

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -215,6 +215,7 @@ class Table extends Component
                                 @if($selectable)
                                     <th class="w-1" wire:key="{{ $uuid }}-checkall-{{ implode(',', $getAllIds()) }}">
                                         <input
+                                            id="checkAll-{{ $uuid }}"
                                             type="checkbox"
                                             class="checkbox checkbox-sm"
                                             x-ref="mainCheckbox"
@@ -269,6 +270,7 @@ class Table extends Component
                                     @if($selectable)
                                         <td class="w-1">
                                             <input
+                                                id="checkbox-{{ $uuid }}-{{ $k }}"
                                                 type="checkbox"
                                                 class="checkbox checkbox-sm checkbox-primary"
                                                 value="{{ data_get($row, $selectableKey) }}"

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -57,6 +57,9 @@ class Textarea extends Component
 
                         {{
                             $attributes
+                            ->merge([
+                                'id' => $uuid
+                            ])
                             ->class([
                                 'textarea textarea-primary w-full peer',
                                 'pt-5' => ($inline && $label),

--- a/src/View/Components/ThemeToggle.php
+++ b/src/View/Components/ThemeToggle.php
@@ -27,6 +27,7 @@ class ThemeToggle extends Component
         return <<<'HTML'
                 <div>
                     <label
+                        for="{{ $uuid }}"
                         x-data="{
                             theme: $persist(window.matchMedia('(prefers-color-scheme: dark)').matches ? '{{ $darkTheme }}' : '{{ $lightTheme }}').as('mary-theme'),
                             init() {
@@ -51,7 +52,7 @@ class ThemeToggle extends Component
                         @mary-toggle-theme.window="toggle()"
                         {{ $attributes->class("swap swap-rotate") }}
                     >
-                        <input type="checkbox" class="theme-controller opacity-0" @click="toggle()" :value="theme" />
+                        <input id="{{ $uuid }}" type="checkbox" class="theme-controller opacity-0" @click="toggle()" :value="theme" />
                         <x-mary-icon x-ref="sun" name="o-sun" class="swap-on" />
                         <x-mary-icon x-ref="moon" name="o-moon" class="swap-off"  />
                     </label>

--- a/src/View/Components/Toggle.php
+++ b/src/View/Components/Toggle.php
@@ -8,19 +8,22 @@ use Illuminate\View\Component;
 
 class Toggle extends Component
 {
+    public string $uuid;
+
     public function __construct(
         public ?string $label = null,
         public ?string $hint = null,
         public ?bool $right = false,
         public ?bool $tight = false
     ) {
+        $this->uuid = "mary" . md5(serialize($this));
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
                 <div>
-                    <label class="flex items-center gap-3 cursor-pointer">
+                    <label for="{{ $uuid }}" class="flex items-center gap-3 cursor-pointer">
 
                         @if($right)
                             <span @class(["flex-1" => !$tight])>
@@ -28,7 +31,7 @@ class Toggle extends Component
                             </span>
                         @endif
 
-                        <input type="checkbox" {{ $attributes->whereDoesntStartWith('class') }} {{ $attributes->class(['toggle toggle-primary']) }}  />
+                        <input id="{{ $uuid }}" type="checkbox" {{ $attributes->whereDoesntStartWith('class') }} {{ $attributes->class(['toggle toggle-primary']) }}  />
 
                         @if(!$right)
                             {{ $label}}


### PR DESCRIPTION
Closes #454 

- Adds `label for="xxx"` and `id` whenever  it is possible, because some components does not have a visible "input" associated with its "label". 
- In some cases `<label for="xxx">` was replaced for `<div>`.


**Needs help** from community to check if something is broken. Despite the branch's name, all the components from this PR must be checked.

```
composer require robsontenorio/mary:dev-main-toggle
php artisan view:clear
```

