### PR TITLE
Table: add `$loop` to `@scope` (breaking change)

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -207,7 +207,7 @@ class MaryServiceProvider extends ServiceProvider
              */
             $name = str_replace('.', '___', $name);
 
-            return "<?php \$__env->slot({$name}, function({$functionArguments}) use ({$uses}) { ?>";
+            return "<?php \$loop = null; \$__env->slot({$name}, function({$functionArguments}) use ({$uses}) { \$loop = (object) \$__env->getLoopStack()[0] ?>";
         });
 
         Blade::directive('endscope', function () {

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -259,11 +259,6 @@ class Table extends Component
                         <!-- ROWS -->
                         <tbody>
                             @foreach($rows as $k => $row)
-                                @php
-                                    # helper variable to provide the loop context
-                                    $this->loop = $loop;
-                                @endphp
-
                                 <tr wire:key="{{ $uuid }}-{{ $k }}" class="hover:bg-base-200/50 {{ $rowClasses($row) }}" @click="$dispatch('row-click', {{ json_encode($row) }});">
                                     <!-- CHECKBOX -->
                                     @if($selectable)


### PR DESCRIPTION
Closes #466 

Breaking change, for good.

**BEFORE** (`$this->loop->index`)

```blade
<x-table ...>
    @scope('cell_name', $user)
        ({{  $this->loop->index }}) {{ $user->name }}
    @endscope
</x-table>
```


**AFTER** (`$loop->index`)
```blade
<x-table ...>
    @scope('cell_name', $user)
        ({{  $loop->index }}) {{ $user->name }}
    @endscope
</x-table>
```