### PR TITLE
Radio: add `null` option 

### DIFF
--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -18,6 +18,7 @@ class Radio extends Component
         public ?string $optionValue = 'id',
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
+        public ?string $nullOption = null,
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-red-500 label-text-alt p-1',
@@ -64,6 +65,16 @@ class Radio extends Component
                                 {{ $attributes->class(["join-item capitalize btn input-bordered input bg-base-200"]) }}
                                 />
                         @endforeach
+                        @if ($nullOption)
+                            <input
+                                type="radio"
+                                name="{{ $modelName() }}"
+                                value=""
+                                aria-label="{{ $nullOption }}"
+                                {{ $attributes->whereStartsWith('wire:model') }}
+                                {{ $attributes->class(["join-item capitalize btn input-bordered input bg-base-200"]) }}
+                            />
+                        @endif
                     </div>
                     <!-- ERROR -->
                     @if(!$omitError && $errors->has($errorFieldName()))


### PR DESCRIPTION
Could be useful if the `Radio` component had a property for allowing a `null` option which doesn't need to be explicitly passed into the `:options` property.

This would be useful for creating filter options in an index page.

### Example 1

Instead  of:

```html
@php
    $subjectOptions = Subject::all();
    $subjectOptions->prepend(['name' => 'All Subjects', 'id' => null]);
@endphp

<x-radio :options="$subjectOptions" wire:model.live="subjectId" />
```

We could do something like this:

```html
@php
    $subjectOptions = Subject::all();
@endphp

<x-radio :options="$subjectOptions" wire:model.live="subjectId" null-option="All Subjects" />
```

![image](https://github.com/robsontenorio/mary/assets/30857718/04ba3c30-f46e-4510-9207-aa04e7e2ddb4)

### Example 2

Here is another example but with an Enum instead:

```php
namespace App\Enums;

enum UserSex: string
{
    case Male = 'm';
    case Female = 'f';
}
```

Instead of

```html
@php
    $sexOptions = UserSex::cases();
    $sexOptions[] = ['name' => 'Any', 'value' => null];
@endphp

<x-radio label="Gender" :options="$sexOptions" option-value="value" wire:model.live="sex" />
```

We could do something like this:

```html
@php
    $sexOptions = UserSex::cases();
@endphp

<x-radio label="Gender" :options="$sexOptions" option-value="value" wire:model.live="sex" null-option="Any" />
```

![image](https://github.com/robsontenorio/mary/assets/30857718/40bb1aad-a3c2-452a-8608-a98a03f93852)
