### PR TITLE
Select : allow Enums

### DIFF
--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -103,7 +103,11 @@ class Select extends Component
                         @endif
 
                         @foreach ($options as $option)
-                            <option value="{{ $option[$optionValue] }}" @if(isset($option['disabled'])) disabled @endif>{{ $option[$optionLabel] }}</option>
+                            @if (is_array($option))
+                                <option value="{{ $option[$optionValue] }}" @if(isset($option['disabled'])) disabled @endif>{{ $option[$optionLabel] }}</option>
+                            @else
+                                <option value="{{ $option->value }}">{{ $option->name }}</option>
+                            @endif
                         @endforeach
                     </select>
 

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -9,7 +9,6 @@ use Illuminate\View\Component;
 
 class Select extends Component
 {
-
     public string $uuid;
 
     public function __construct(
@@ -32,8 +31,7 @@ class Select extends Component
         public ?string $errorClass = 'text-red-500 label-text-alt p-1',
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
-    )
-    {
+    ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
 
@@ -103,11 +101,7 @@ class Select extends Component
                         @endif
 
                         @foreach ($options as $option)
-                            @if (is_array($option))
-                                <option value="{{ $option[$optionValue] }}" @if(isset($option['disabled'])) disabled @endif>{{ $option[$optionLabel] }}</option>
-                            @else
-                                <option value="{{ $option->value }}">{{ $option->name }}</option>
-                            @endif
+                            <option value="{{ data_get($option, $optionValue) }}" @if(data_get($option, 'disabled')) disabled @endif>{{ data_get($option, $optionLabel) }}</option>
                         @endforeach
                     </select>
 


### PR DESCRIPTION
Currently `<x-select>` seems to only work with simple arrays.

If we tried passing in an Enum

```html
@php
    $statusOptions = \App\Enums\PostStatus::cases();
@endphp

<x-select label="Status" :options="$statusOptions" wire:model="status" />
```

We would get the following error

```
Cannot use object of type App\Enums\PostStatus as array
```

