### PR TITLE
Fix ImageLibrary block on crop error

### DIFF
--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -119,7 +119,7 @@ class ImageLibrary extends Component
                             this.cropper.getCroppedCanvas().toBlob((blob) => {
                                 @this.upload(this.croppingId, blob,
                                     (uploadedFilename) => { this.refreshMediaSources() },
-                                    (error) => {  },
+                                    (error) => { this.progress = 0; },
                                     (event) => { this.progress = event.detail.progress;  }
                                 )
                             })


### PR DESCRIPTION
When an error occurs while saving the crop the progress is not resetted so the component becomes unusable. By entering this small piece of code the error is displayed and you can continue using the component. To replicate the mistake: trying a crop on a large image with a size close to the upload limit threshold (the crop library produces a blob with a larger size than the original file)