### PR TITLE
DropdownComponent add new parameter "no-x-anchor" and "top"

### DIFF
--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -29,12 +29,11 @@ class Dropdown extends Component
                 x-data="{open: false}"
                 @click.outside="open = false"
                 :open="open"
-                class="dropdown"
                 @class([
                     'dropdown',
-                    'dropdown-right' => ($noXAnchor && $right),
+                    'dropdown-end' => ($noXAnchor && $right),
                     'dropdown-top' => ($noXAnchor && $top),
-                    'dropdown-end' => $noXAnchor,
+                    'dropdown-bottom' => $noXAnchor,
                 ])
             >
                 <!-- CUSTOM TRIGGER -->
@@ -51,13 +50,13 @@ class Dropdown extends Component
                 @endif
 
                 <ul
-                    @class([ 
+                    @class([
                         'p-2','shadow','menu','z-[1]','border','border-base-200','bg-base-100','dark:bg-base-200','rounded-box','w-auto','min-w-max',
                         'dropdown-content' => $noXAnchor,
-                    ]) 
+                    ])
                     @click="open = false"
                     @if(!$noXAnchor)
-                    x-anchor.{{ $right ? 'bottom-end' : 'bottom-start' }}="$refs.button"
+                        x-anchor.{{ $right ? 'bottom-end' : 'bottom-start' }}="$refs.button"
                     @endif
                 >
                     <div wire:key="dropdown-slot-{{ $uuid }}">

--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -14,7 +14,8 @@ class Dropdown extends Component
         public ?string $label = null,
         public ?string $icon = 'o-chevron-down',
         public ?bool $right = false,
-
+        public ?bool $top = false,
+        public ?bool $noXAnchor = false,
         // Slots
         public mixed $trigger = null
     ) {
@@ -29,6 +30,12 @@ class Dropdown extends Component
                 @click.outside="open = false"
                 :open="open"
                 class="dropdown"
+                @class([
+                    'dropdown',
+                    'dropdown-right' => ($noXAnchor && $right),
+                    'dropdown-top' => ($noXAnchor && $top),
+                    'dropdown-end' => $noXAnchor,
+                ])
             >
                 <!-- CUSTOM TRIGGER -->
                 @if($trigger)
@@ -44,9 +51,14 @@ class Dropdown extends Component
                 @endif
 
                 <ul
-                    class="p-2 shadow menu z-[1] border border-base-200 bg-base-100 dark:bg-base-200 rounded-box w-auto min-w-max"
+                    @class([ 
+                        'p-2','shadow','menu','z-[1]','border','border-base-200','bg-base-100','dark:bg-base-200','rounded-box','w-auto','min-w-max',
+                        'dropdown-content' => $noXAnchor,
+                    ]) 
                     @click="open = false"
+                    @if(!$noXAnchor)
                     x-anchor.{{ $right ? 'bottom-end' : 'bottom-start' }}="$refs.button"
+                    @endif
                 >
                     <div wire:key="dropdown-slot-{{ $uuid }}">
                         {{ $slot }}


### PR DESCRIPTION
When there are a lot of Dropdown components side by side, the performance is very slow due to x-anchor

For this reason, we added the "no-x-anchor" property.

However, since there are cases where the menu expanded on the screen is filled up, we also added the "top" property.


```php
<x-dropdown no-x-anchor top>
....
```