### PR TITLE
Add 'enabled' property to MenuSub and MenuItem components

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -22,7 +22,8 @@ class MenuItem extends Component
         public ?string $badge = null,
         public ?string $badgeClasses = null,
         public ?bool $active = false,
-        public ?bool $separator = false
+        public ?bool $separator = false,
+        public ?bool $enabled = true,
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
@@ -49,6 +50,10 @@ class MenuItem extends Component
 
     public function render(): View|Closure|string
     {
+        if ($this->enabled === false) {
+            return '';
+        }
+
         return <<<'HTML'
                 @aware(['activateByRoute' => false, 'activeBgColor' => 'bg-base-300'])
 

--- a/src/View/Components/MenuSub.php
+++ b/src/View/Components/MenuSub.php
@@ -14,12 +14,17 @@ class MenuSub extends Component
         public ?string $title = null,
         public ?string $icon = null,
         public bool $open = false,
+        public ?bool $enabled = true,
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
 
     public function render(): View|Closure|string
     {
+        if ($this->enabled === false) {
+            return '';
+        }
+
         return <<<'HTML'
                 @aware(['activeBgColor' => 'bg-base-300'])
 


### PR DESCRIPTION
The 'enabled' property has been introduced into the MenuSub and MenuItem components. The render function in both components is now also checking this 'enabled' property. If a component is not enabled, it will now return an empty string and thus not render. This provides more flexibility when controlling the visibility of the components.

We can easily put an `if` before the menu-item but this way it is more manageable for the user

```php
<?php


return [
    'main' => [
        [
            'title'       => 'Dashboard',
            'description' => 'Go to dashboard',
            'icon'        => 'o-chart-pie',
            'link'        => '/',
        ],
        [
            'title'       => 'Tasks',
            'icon'        => 'o-tag',
            'description' => 'Manage tasks',
            'link'        => '/tasks',
        ],
        [
            'type' => 'separator',
        ],
        [
            'title' => 'Settings',
            'icon'  => 'o-wrench-screwdriver',
            'sub'   => [
                [
                    'title'       => 'Users',
                    'link'        => '/management/users',
                    'description' => 'Manage users',
                    'permission'  => 'viewAny Task',
                ],
                [
                    'title'       => 'Roles',
                    'link'        => '/management/roles',
                    'description' => 'Manage Roles',
                    'permission'  => 'management',
                ],
                [
                    'title'       => 'Permissions',
                    'link'        => '/management/permissions',
                    'description' => 'Manage Permissions',
                    'permission'  => 'management',
                ],
                [
                    'title'       => 'Activity Log',
                    'link'        => '/management/activity-log',
                    'description' => 'Show activity logs events',
                    'permission'  => 'management',
                ],
            ],
        ],
    ],
];
```

```blade
<x-menu activate-by-route>
    @foreach(config('app.menu.main') as $menu)
        @if(isset($menu['type']) && $menu['type'] === 'separator')
            <x-menu-separator/>
            @continue
        @endif
        @if(isset($menu['sub']))
            <x-menu-sub :title="$menu['title']" :icon="$menu['icon'] ?? null" :enabled="isset($menu['permission']) ? auth()->user()->can($menu['permission']) : true">
                @foreach($menu['sub'] as $sub)
                    <x-menu-item :title="$sub['title']" :link="$sub['link']" :icon="$sub['icon'] ?? null" :enabled="isset($sub['permission']) ? auth()->user()->can($sub['permission']) : true" />
                @endforeach
            </x-menu-sub>
        @else
            <x-menu-item :title="$menu['title']" :icon="$menu['icon'] ?? null" :link="$menu['link']" :enabled="isset($menu['permission']) ? auth()->user()->can($menu['permission']) : true"/>
        @endif
    @endforeach
    <x-menu-separator/>
    <x-menu-item title="Search" @click.stop="$dispatch('mary-search-open')" icon="o-magnifying-glass" class="max-h-screen-2xl mh-auto"
                 badge="Cmd + G"/>
</x-menu>

```
