### PR TITLE
Sidebar: add `right` and `right-mobile`

### DIFF
--- a/src/View/Components/Main.php
+++ b/src/View/Components/Main.php
@@ -29,7 +29,11 @@ class Main extends Component
     {
         return <<<'HTML'
                  <main @class(["w-full mx-auto", "max-w-screen-2xl" => !$fullWidth])>
-                    <div class="drawer lg:drawer-open">
+                    <div @class([
+                        "drawer lg:drawer-open",
+                        "drawer-end" => $sidebar?->attributes['right'],
+                        "max-sm:drawer-end" => $sidebar?->attributes['right-mobile'],
+                    ])>
                         <input id="{{ $sidebar?->attributes['drawer'] }}" type="checkbox" class="drawer-toggle" />
                         <div {{ $content->attributes->class(["drawer-content w-full mx-auto p-5 lg:px-10 lg:py-5"]) }}>
                             <!-- MAIN CONTENT -->


### PR DESCRIPTION
Closes #525 

<img width="760" alt="image" src="https://github.com/user-attachments/assets/6bac4e4a-5309-45dd-a64a-1b3595ab24f1">


