### PR TITLE
Fix empty $rows validation

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -366,7 +366,7 @@ class Table extends Component
                         </tbody>
                     </table>
 
-                    @if(empty($rows))
+                    @if(count($rows) === 0)
                         @if($showEmptyText)
                             <div class="text-center py-4 text-gray-500 dark:text-gray-400">
                                 {{ $emptyText }}


### PR DESCRIPTION
empty() doesn't work if $rows is a Paginator