### PR TITLE
Fix Drawer component binding condition

### DIFF
--- a/src/View/Components/Drawer.php
+++ b/src/View/Components/Drawer.php
@@ -42,7 +42,7 @@ class Drawer extends Component
                 <div
                     x-data="{
                         open:
-                            @if($modelName())
+                            @if($modelName()->value)
                                 @entangle($modelName())
                             @else
                                 false


### PR DESCRIPTION
Update Drawer component to properly check modelName value for binding. This ensures the drawer functionality correctly reflects the model's state, improving reliability and accuracy.

Fix when not using model binding:

```blade
<x-drawer id="asdf" title="asdf" separator class="w-11/12 lg:w-1/3 bg-primary !text-white" right>
```

<img width="770" alt="image" src="https://github.com/user-attachments/assets/37b3b437-ffba-47be-8f16-3cc8f2f0abfd">

```html
.entangle('')   
```