### PR TITLE
Textarea: fix duplicated html id when using nested models.

### DIFF
--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -58,12 +58,13 @@ class Textarea extends Component
                 <div class="flex-1 relative">
                     <!-- INPUT -->
                     <textarea
-                        id="{{ $uuid }}"
                         placeholder = "{{ $attributes->whereStartsWith('placeholder')->first() }} "
 
                         {{
                             $attributes
-                            ->merge([])
+                             ->merge([
+                                 'id' => $uuid
+                             ])
                             ->class([
                                 'textarea textarea-primary w-full peer',
                                 'pt-5' => ($inline && $label),

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -37,6 +37,11 @@ class Textarea extends Component
     {
         return <<<'HTML'
             <div>
+                @php
+                    // Wee need this extra step to support models arrays. Ex: wire:model="emails.0"  , wire:model="emails.1"
+                    $uuid = $uuid . $modelName()
+                @endphp
+
                 <!-- STANDARD LABEL -->
                 @if($label && !$inline)
                     <label for="{{ $uuid }}" class="pt-0 label label-text font-semibold">
@@ -53,13 +58,12 @@ class Textarea extends Component
                 <div class="flex-1 relative">
                     <!-- INPUT -->
                     <textarea
+                        id="{{ $uuid }}"
                         placeholder = "{{ $attributes->whereStartsWith('placeholder')->first() }} "
 
                         {{
                             $attributes
-                            ->merge([
-                                'id' => $uuid
-                            ])
+                            ->merge([])
                             ->class([
                                 'textarea textarea-primary w-full peer',
                                 'pt-5' => ($inline && $label),

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -62,9 +62,9 @@ class Textarea extends Component
 
                         {{
                             $attributes
-                             ->merge([
-                                 'id' => $uuid
-                             ])
+                            ->merge([
+                                'id' => $uuid
+                            ])
                             ->class([
                                 'textarea textarea-primary w-full peer',
                                 'pt-5' => ($inline && $label),


### PR DESCRIPTION
Currently when clicking the label of a textarea that has an id it will not focus the associated input. 
This pull request fixes the issue by using the same logic as the Input.php component.