### PR TITLE
Colorpicker: add focus outline for input with type color

### DIFF
--- a/src/View/Components/Colorpicker.php
+++ b/src/View/Components/Colorpicker.php
@@ -65,6 +65,7 @@ class Colorpicker extends Component
                         @class([
                                 "rounded-s-lg flex items-center",
                                 "border border-primary border-e-0 px-4 cursor-pointer",
+                                "focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary",
                                 "border-0 bg-base-300" => $attributes->has('disabled') && $attributes->get('disabled') == true,
                                 "border-dashed" => $attributes->has('readonly') && $attributes->get('readonly') == true,
                                 "!border-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError


### PR DESCRIPTION
Currently the color input of the Colorpicker has no focus styles. There is no feedback on whether it is focused or not.
This pull request adds the focus styles a primary input has.

![image](https://github.com/user-attachments/assets/66847ea8-4743-485a-845d-84738041ef7d)
