### PR TITLE
Resolve erroneous route matching in menus

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -45,7 +45,7 @@ class MenuItem extends Component
             return true;
         }
 
-        return $this->link != '/' && Str::startsWith($route, $link);
+        return $this->link != '/' && Str::is($route, $link);
     }
 
     public function render(): View|Closure|string


### PR DESCRIPTION
Using the `activate-by-route` attribute will erroneously match links that have the same prefix. 

For example, these two links will show as active:

1. /users/1
2. /users/101

This is because of this line: 

    return $this->link != '/' && Str::startsWith($route, $link);

Which instead should be:

    return $this->link != '/' && Str::is($route, $link);

To avoid matching links that start with another matching link.

Screenshot for reference:

<img width="969" alt="image" src="https://github.com/user-attachments/assets/1477ec40-75b0-413b-9e8f-245313894728">
