### PR TITLE
MenuItem: Adds optional `exact`  attribute on menu items

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -24,6 +24,7 @@ class MenuItem extends Component
         public ?bool $active = false,
         public ?bool $separator = false,
         public ?bool $enabled = true,
+        public ?bool $exact = false
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
@@ -45,7 +46,7 @@ class MenuItem extends Component
             return true;
         }
 
-        return $this->link != '/' && Str::is($route, $link);
+        return !$this->exact && $this->link != '/' && Str::startsWith($route, $link);
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -45,7 +45,7 @@ class MenuItem extends Component
             return true;
         }
 
-        return $this->link != '/' && Str::startsWith($route, $link);
+        return $this->link != '/' && Str::is($route, $link);
     }
 
     public function render(): View|Closure|string


### PR DESCRIPTION
The `exact` attribute requires the link and route to match exactly in order to show as active in a menu.

This leaves the default functionality of fuzzy-ish matching parent routes, but also avoids issues with numeric IDs unintentionally matching (e.g. ID # 1 and ID # 11 should not match).

Example usage:

```
<x-menu-item title="{{ __('Transactions') }}" icon="o-banknotes" link="####" exact />
//                                                                             ^
```

Ref: #549 