### PR TITLE
Editor/Markdow: allow to change contents on the fly

### DIFF
--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -5,7 +5,6 @@ namespace Mary\View\Components;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
-use Livewire\Attributes\On;
 
 class Editor extends Component
 {
@@ -27,12 +26,6 @@ class Editor extends Component
     ) {
         $this->uuid = "mary" . md5(serialize($this));
         $this->uploadUrl = route('mary.upload', absolute: false);
-    }
-
-    #[On('refresh-editor')]
-    public function refreshEditor()
-    {
-
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -103,6 +103,10 @@ class Editor extends Component
                                     editor.on('change', (e) => value = editor.getContent())
                                     editor.on('init', () =>  editor.setContent(value ?? ''))
                                     editor.on('OpenWindow', (e) => tinymce.activeEditor.topLevelWindow = e.dialog)
+                                    $watch('value', function (newValue) {
+                                        if (newValue !== editor.getContent()) {
+                                        editor.resetContent(newValue || '');
+                                    }})
                                 },
                                 file_picker_callback: function(cb, value, meta) {
                                     const formData = new FormData()

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -103,10 +103,13 @@ class Editor extends Component
                                     editor.on('change', (e) => value = editor.getContent())
                                     editor.on('init', () =>  editor.setContent(value ?? ''))
                                     editor.on('OpenWindow', (e) => tinymce.activeEditor.topLevelWindow = e.dialog)
+
+                                    // Handles a case where people try to change contents on the fly from Livewire methods
                                     $watch('value', function (newValue) {
                                         if (newValue !== editor.getContent()) {
-                                        editor.resetContent(newValue || '');
-                                    }})
+                                            editor.resetContent(newValue || '');
+                                        }
+                                    })
                                 },
                                 file_picker_callback: function(cb, value, meta) {
                                     const formData = new FormData()

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -89,6 +89,22 @@ class Markdown extends Component
                             uploadUrl: '{{ $uploadUrl }}?disk={{ $disk }}&folder={{ $folder }}&_token={{ csrf_token() }}',
                             uploading: false,
                             init() {
+                                this.initEditor()
+
+                                // Handles a case where people try to change contents on the fly from Livewire methods
+                                this.$watch('value', (newValue) => {
+                                    if (newValue !== this.editor.value()) {
+                                        this.value = newValue || ''
+                                        this.destroyEditor()
+                                        this.initEditor()
+                                    }
+                                })
+                            },
+                            destroyEditor() {
+                                this.editor.toTextArea();
+                                this.editor = null
+                            },
+                            initEditor() {
                                 this.editor = new EasyMDE({
                                         {{ $setup() }},
                                         element: $refs.markdown{{ $uuid }},
@@ -115,7 +131,7 @@ class Markdown extends Component
                             }
                         }"
                     wire:ignore
-                    x-on:livewire:navigating.window="editor.toTextArea(); editor = null"
+                    x-on:livewire:navigating.window="destroyEditor()"
                 >
                     <div class="relative disabled" :class="uploading && 'pointer-events-none opacity-50'">
                         <textarea id="{{ $uuid }}" x-ref="markdown{{ $uuid }}"></textarea>


### PR DESCRIPTION
Add refreshEditor method to Editor component

Introduce a new `refreshEditor` method in the Editor component and enhance the editor initialization with a watcher for content updates, ensuring synchronization between the editor content and the Livewire model. This update improves the component's reactivity and handling of dynamic content changes.