### PR TITLE
Remove # default src in crop modal

### DIFF
--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -196,7 +196,7 @@ class File extends Component
                         <!-- CROP MODAL -->
                         <div @click.prevent="" x-ref="crop" wire:ignore>
                             <x-mary-modal id="maryCrop{{ $uuid }}" x-ref="maryCrop" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="">
-                                <img src="#" />
+                                <img src="" />
                                 <x-slot:actions>
                                     <x-mary-button :label="$cropCancelText" @click="close()" />
                                     <x-mary-button :label="$cropSaveText" class="btn-primary" @click="save()" ::disabled="processing" />


### PR DESCRIPTION
Resolves #575 

Using `#` as `src` in an `img` element downloads the page.
It is a good placeholder for `a:href`, not `img:src`.