### PR TITLE
Allow UUIDs and other string as expandableKey

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -306,7 +306,7 @@ class Table extends Component
                                                 name="o-chevron-down"
                                                 ::class="isExpanded({{ data_get($row, $expandableKey) }}) || '-rotate-90 !text-current !bg-base-200'"
                                                 class="cursor-pointer p-2 w-8 h-8 bg-base-300 rounded-lg"
-                                                @click="toggleExpand({{ data_get($row, $expandableKey) }});" />
+                                                @click="toggleExpand('{{ data_get($row, $expandableKey) }}');" />
                                         </td>
                                      @endif
 

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -304,7 +304,7 @@ class Table extends Component
                                         <td class="w-1 pe-0">
                                             <x-mary-icon
                                                 name="o-chevron-down"
-                                                ::class="isExpanded({{ data_get($row, $expandableKey) }}) || '-rotate-90 !text-current !bg-base-200'"
+                                                ::class="isExpanded('{{ data_get($row, $expandableKey) }}') || '-rotate-90 !text-current !bg-base-200'"
                                                 class="cursor-pointer p-2 w-8 h-8 bg-base-300 rounded-lg"
                                                 @click="toggleExpand('{{ data_get($row, $expandableKey) }}');" />
                                         </td>
@@ -357,7 +357,7 @@ class Table extends Component
 
                                 <!-- EXPANSION SLOT -->
                                 @if($expandable)
-                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" :class="isExpanded({{ data_get($row, $expandableKey) }}) || 'hidden'">
+                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" :class="isExpanded('{{ data_get($row, $expandableKey) }}') || 'hidden'">
                                         <td :colspan="colspanSize">
                                             {{ $expansion($row) }}
                                         </td>


### PR DESCRIPTION
Hi,

at moment it is not possible to use uuid or strings as expandable key.
With this fix the problem should be fixed.

best regards
Fabian