### PR TITLE
Table: Added an option to disable link in a given column via 'disable-link' header

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -86,6 +86,12 @@ class Table extends Component
         return $header['hidden'] ?? false;
     }
 
+    // Check if link should be shown in cell
+    public function hasLink(mixed $header): bool
+    {
+        return $this->link && empty($header['disableLink']);
+    }
+
     // Check if is currently sorted by this header
     public function isSortedBy(mixed $header): bool
     {
@@ -323,26 +329,26 @@ class Table extends Component
 
                                         <!--  HAS CUSTOM SLOT ? -->
                                         @if(isset(${"cell_".$temp_key}))
-                                            <td @class([$cellClasses($row, $header), "p-0" => $link])>
-                                                @if($link)
+                                            <td @class([$cellClasses($row, $header), "p-0" => $hasLink($header)])>
+                                                @if($hasLink($header))
                                                     <a href="{{ $redirectLink($row) }}" wire:navigate class="block py-3 px-4">
                                                 @endif
 
                                                 {{ ${"cell_".$temp_key}($row)  }}
 
-                                                @if($link)
+                                                @if($hasLink($header))
                                                     </a>
                                                  @endif
                                             </td>
                                         @else
-                                            <td @class([$cellClasses($row, $header), "p-0" => $link])>
-                                                @if($link)
+                                            <td @class([$cellClasses($row, $header), "p-0" => $hasLink($header)])>
+                                                @if($hasLink($header))
                                                     <a href="{{ $redirectLink($row) }}" wire:navigate class="block py-3 px-4">
                                                 @endif
 
                                                 {{ data_get($row, $header['key']) }}
 
-                                                @if($link)
+                                                @if($hasLink($header))
                                                     </a>
                                                 @endif
                                             </td>


### PR DESCRIPTION
I added an option in table headers to disable the global link from `<x-table link="/my-link" >` for a given column, useful when you want a column to have a custom link via `@scope('cell_.....')` 

To use it you just add the `'disableLink' => true` attribute to your header like this :

```php
 public function headers(): array
    {
        return [
            ['key' => 'id', 'label' => '#', 'class' => 'hidden lg:table-cell'],
            ['key' => 'name', 'label' => 'Permission', 'sortBy' => 'name', 'disableLink' => true] , // <--- here
            ['key' => 'description', 'label' => 'Description', 'sortBy' => 'description'],
        ];
    }
```