### PR TITLE
MenuItems: handle no title 

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -83,6 +83,7 @@ class MenuItem extends Component
                             <x-mary-icon :name="$icon" />
                         @endif
 
+                        @if($title || $slot->isNotEmpty())
                         <span class="mary-hideable whitespace-nowrap truncate">
                             @if($title)
                                 {{ $title }}
@@ -94,6 +95,7 @@ class MenuItem extends Component
                                 {{ $slot }}
                             @endif
                         </span>
+                        @endif
                     </a>
                 </li>
             HTML;


### PR DESCRIPTION
When a <x-menu-item/> is created without a tittle, an empty div is rendered.
 
![Screenshot from 2024-08-27 19-33-54](https://github.com/user-attachments/assets/2cc654f9-c86d-4080-b60f-0598f15aad47)
![image](https://github.com/user-attachments/assets/e27142be-c96d-44ad-9172-41d67104fcc6)


Fix
![image](https://github.com/user-attachments/assets/1c2f64ae-e74a-4c79-8358-3e49c3409411)
