### PR TITLE
Table: allow striped + expandable

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -228,8 +228,11 @@ class Table extends Component
                                 ->except('wire:model')
                                 ->class([
                                     'table',
-                                    'table-zebra' => $striped,
-                                    'cursor-pointer' => $attributes->hasAny(['@row-click', 'link'])
+                                    'table-zebra' => $striped && !$expandable,
+                                    'cursor-pointer' => $attributes->hasAny(['@row-click', 'link']),
+                                    '[&_tr:nth-child(4n+3):not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))]' => $expandable,
+                                    '[&_tr:nth-child(4n+3):not(.expansion):hover]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $expandable,
+                                    '[&_tr.active:not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))] [&_tr.active:nth-child(even):not(.expansion)]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $expandable,
                                 ])
                         }}
                     >
@@ -313,7 +316,7 @@ class Table extends Component
                                         <td class="w-1 pe-0">
                                             <x-mary-icon
                                                 name="o-chevron-down"
-                                                ::class="isExpanded('{{ data_get($row, $expandableKey) }}') || '-rotate-90 !text-current !bg-base-200'"
+                                                ::class="isExpanded('{{ data_get($row, $expandableKey) }}') || '-rotate-90 !text-current'"
                                                 class="cursor-pointer p-2 w-8 h-8 bg-base-300 rounded-lg"
                                                 @click="toggleExpand('{{ data_get($row, $expandableKey) }}');" />
                                         </td>
@@ -366,7 +369,7 @@ class Table extends Component
 
                                 <!-- EXPANSION SLOT -->
                                 @if($expandable)
-                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" :class="isExpanded('{{ data_get($row, $expandableKey) }}') || 'hidden'">
+                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="expansion [&:nth-child(4n)]:!bg-[oklch(var(--b2)/var(--tw-bg-opacity))]" :class="isExpanded('{{ data_get($row, $expandableKey) }}') || 'hidden'">
                                         <td :colspan="colspanSize">
                                             {{ $expansion($row) }}
                                         </td>

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -230,9 +230,9 @@ class Table extends Component
                                     'table',
                                     'table-zebra' => $striped && !$expandable,
                                     'cursor-pointer' => $attributes->hasAny(['@row-click', 'link']),
-                                    '[&_tr:nth-child(4n+3):not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))]' => $expandable,
-                                    '[&_tr:nth-child(4n+3):not(.expansion):hover]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $expandable,
-                                    '[&_tr.active:not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))] [&_tr.active:nth-child(even):not(.expansion)]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $expandable,
+                                    '[&_tr:nth-child(4n+3):not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))]' => $striped && $expandable,
+                                    '[&_tr:nth-child(4n+3):not(.expansion):hover]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $striped && $expandable,
+                                    '[&_tr.active:not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))] [&_tr.active:nth-child(even):not(.expansion)]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $striped && $expandable,
                                 ])
                         }}
                     >

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -228,11 +228,9 @@ class Table extends Component
                                 ->except('wire:model')
                                 ->class([
                                     'table',
-                                    'table-zebra' => $striped && !$expandable,
-                                    'cursor-pointer' => $attributes->hasAny(['@row-click', 'link']),
-                                    '[&_tr:nth-child(4n+3):not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))]' => $striped && $expandable,
-                                    '[&_tr:nth-child(4n+3):not(.expansion):hover]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $striped && $expandable,
-                                    '[&_tr.active:not(.expansion)]:bg-[oklch(var(--b2)/var(--tw-bg-opacity))] [&_tr.active:nth-child(even):not(.expansion)]:bg-[oklch(var(--b3)/var(--tw-bg-opacity))]' => $striped && $expandable,
+                                    'table-zebra' => $striped,
+                                    '[&_tr:nth-child(4n+3)]:bg-base-200' => $striped && $expandable,
+                                    'cursor-pointer' => $attributes->hasAny(['@row-click', 'link'])
                                 ])
                         }}
                     >
@@ -369,7 +367,7 @@ class Table extends Component
 
                                 <!-- EXPANSION SLOT -->
                                 @if($expandable)
-                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="expansion [&:nth-child(4n)]:!bg-[oklch(var(--b2)/var(--tw-bg-opacity))]" :class="isExpanded('{{ data_get($row, $expandableKey) }}') || 'hidden'">
+                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="!bg-inherit" :class="isExpanded('{{ data_get($row, $expandableKey) }}') || 'hidden'">
                                         <td :colspan="colspanSize">
                                             {{ $expansion($row) }}
                                         </td>


### PR DESCRIPTION
- Fixed issue with zebra striping not being applied to `table` when rows are `expandable`.
- Updated `nth-child` selectors to correctly handle every `4th` and `3rd` rows.
- Resolved conflicts between hover states and expanded rows using dynamic `::class` and `class` bindings.

## Bug Report:

MaryUI version: `^1.20`
Livewire version: `^3.5`

## Affected Browsers:

- Chrome
- Firefox
- Safari
- Edge

## What Happened?

- Zebra Striping Issue: Rows with the expandable feature were affected by zebra striping, causing inconsistent row styling, particularly on hover.

## Screencast:

https://github.com/user-attachments/assets/e69466ef-bd36-46ce-b7c2-0f1330765cd7

