### PR TITLE
Table: fix wire model modifiers like wire:model.live

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -228,8 +228,6 @@ class Table extends Component
                              }"
                 >
                 <div class="overflow-x-auto">
-                CASA
-                @dump($getAllIds());
                 <table
                         {{
                             $attributes

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -68,7 +68,7 @@ class Table extends Component
     {
         // Pagination
         if ($this->rows instanceof ArrayAccess) {
-            return $this->rows->pluck($this->selectableKey)->all();
+            return collect($this->rows)->pluck($this->selectableKey)->all();
         }
 
         return collect($this->rows)->pluck($this->selectableKey)->all();
@@ -114,7 +114,7 @@ class Table extends Component
         }
 
         $direction = $this->isSortedBy($header)
-            ? $this->sortBy['direction'] == 'asc' ? 'desc' : 'asc'
+            ? $this->sortBy['direction'] == ('asc' ? 'desc' : 'asc')
             : 'asc';
 
         return ['column' => $header['sortBy'] ?? $header['key'], 'direction' => $direction];
@@ -225,7 +225,7 @@ class Table extends Component
                 <table
                         {{
                             $attributes
-                                ->except('wire:model')
+                                ->whereDoesntStartWith('wire:model')
                                 ->class([
                                     'table',
                                     'table-zebra' => $striped,

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -66,12 +66,11 @@ class Table extends Component
     // Get all ids for selectable and expandable features
     public function getAllIds(): array
     {
-        // Pagination
-        if ($this->rows instanceof ArrayAccess) {
+        if (is_array($this->rows)) {
             return collect($this->rows)->pluck($this->selectableKey)->all();
         }
 
-        return collect($this->rows)->pluck($this->selectableKey)->all();
+        return $this->rows->pluck($this->selectableKey)->all();
     }
 
     // Check if header is sortable
@@ -170,6 +169,13 @@ class Table extends Component
         return is_string($this->getAllIds()[0] ?? null) ? "" : ".number";
     }
 
+    public function getKeyValue($row, $key): mixed
+    {
+        $value = data_get($row, $this->$key);
+
+        return is_numeric($value) && ! str($value)->startsWith('0') ? $value : "'$value'";
+    }
+
     public function render(): View|Closure|string
     {
         return <<<'HTML'
@@ -222,6 +228,8 @@ class Table extends Component
                              }"
                 >
                 <div class="overflow-x-auto">
+                CASA
+                @dump($getAllIds());
                 <table
                         {{
                             $attributes
@@ -314,9 +322,9 @@ class Table extends Component
                                         <td class="w-1 pe-0">
                                             <x-mary-icon
                                                 name="o-chevron-down"
-                                                ::class="isExpanded('{{ data_get($row, $expandableKey) }}') || '-rotate-90 !text-current'"
+                                                ::class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || '-rotate-90 !text-current'"
                                                 class="cursor-pointer p-2 w-8 h-8 bg-base-300 rounded-lg"
-                                                @click="toggleExpand('{{ data_get($row, $expandableKey) }}');" />
+                                                @click="toggleExpand({{ $getKeyValue($row, 'expandableKey') }});" />
                                         </td>
                                      @endif
 
@@ -367,7 +375,7 @@ class Table extends Component
 
                                 <!-- EXPANSION SLOT -->
                                 @if($expandable)
-                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="!bg-inherit" :class="isExpanded('{{ data_get($row, $expandableKey) }}') || 'hidden'">
+                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="!bg-inherit" :class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || 'hidden'">
                                         <td :colspan="colspanSize">
                                             {{ $expansion($row) }}
                                         </td>


### PR DESCRIPTION
- Fixes Issue #512 and other wire:model modifiers.
- Fixes "Undefined method 'pluck'" on ArrayAccess by converting to Collection.
- Fixes "Nested ternary expressions (without parentheses) deprecated in PHP 7.4. Targeting PHP 8.3.0." by wrapping in parentheses.