### PR TITLE
File: add a filename to the cropped image on save.

### DIFF
--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -119,6 +119,7 @@ class File extends Component
                             this.imageCrop.src = this.imagePreview.src
 
                             this.cropper.getCroppedCanvas().toBlob((blob) => {
+                                blob.name = $wire.el.querySelector('#{{ $uuid }}').files[0].name
                                 @this.upload('{{ $attributes->wire('model')->value }}', blob,
                                     (uploadedFilename) => {  },
                                     (error) => {  },

--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -119,7 +119,7 @@ class File extends Component
                             this.imageCrop.src = this.imagePreview.src
 
                             this.cropper.getCroppedCanvas().toBlob((blob) => {
-                                blob.name = $wire.el.querySelector('#{{ $uuid }}').files[0].name
+                                blob.name = $refs.file.files[0].name
                                 @this.upload('{{ $attributes->wire('model')->value }}', blob,
                                     (uploadedFilename) => {  },
                                     (error) => {  },


### PR DESCRIPTION
Fixes #603 and resolves #568 by providing the info required by Livewire. As newer version of Livewire use `getClientOriginalExtension` and `pathinfo` within said call, a file name is required in some configuration.

ref. https://github.com/livewire/livewire/commit/70503b79f5db75a1eac9bf55826038a6ee5a16d5