### PR TITLE
Fix missing $__bladeCompiler variable in scope directive

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -204,6 +204,7 @@ class MaryServiceProvider extends ServiceProvider
             $uses = Arr::except(array_flip($directiveArguments), [$name, $functionArguments]);
             $uses = array_flip($uses);
             array_push($uses, '$__env');
+            array_push($uses, '$__bladeCompiler');
             $uses = implode(',', $uses);
 
             /**


### PR DESCRIPTION
This fixes the Issue of scope directive throwing an exception with Blade::stringable configuration being present in AppServiceProvider.

https://github.com/robsontenorio/mary/issues/616

