### PR TITLE
Checkbox: add required symbol if given

### DIFF
--- a/src/View/Components/Checkbox.php
+++ b/src/View/Components/Checkbox.php
@@ -44,6 +44,10 @@ class Checkbox extends Component
                         @if($right)
                             <span @class(["flex-1" => !$tight])>
                                 {{ $label}}
+                                
+                                @if($attributes->get('required'))
+                                    <span class="text-error">*</span>
+                                @endif
                             </span>
                         @endif
 
@@ -54,6 +58,10 @@ class Checkbox extends Component
 
                         @if(!$right)
                             {{ $label}}
+                                
+                            @if($attributes->get('required'))
+                                    <span class="text-error">*</span>
+                                @endif
                         @endif
                     </label>
 

--- a/src/View/Components/Checkbox.php
+++ b/src/View/Components/Checkbox.php
@@ -44,7 +44,7 @@ class Checkbox extends Component
                         @if($right)
                             <span @class(["flex-1" => !$tight])>
                                 {{ $label}}
-                                
+
                                 @if($attributes->get('required'))
                                     <span class="text-error">*</span>
                                 @endif
@@ -58,10 +58,10 @@ class Checkbox extends Component
 
                         @if(!$right)
                             {{ $label}}
-                                
+
                             @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
-                                @endif
+                                <span class="text-error">*</span>
+                            @endif
                         @endif
                     </label>
 


### PR DESCRIPTION
This will add the required symbol after the label if the "required" attribute is provided. This was missing and I noticed it while updating the Toggle component.

![image](https://github.com/user-attachments/assets/c9adb78a-b6cd-42bb-a546-d2d778f79ff9)
