### PR TITLE
MenuItem: add support for modifiers on wire:navigate

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -75,7 +75,7 @@ class MenuItem extends Component
                             @endif
 
                             @if(!$external && !$noWireNavigate)
-                                wire:navigate
+                                {{ $attributes->wire('navigate') }}
                             @endif
                         @endif
                     >


### PR DESCRIPTION
As per a comment on discord this PR will add support for modifiers on `wire:navigate` like `wire:navigate.hover` to the MenuItem component.