### PR TITLE
Choices: add support for placeholders

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -101,8 +101,7 @@ class Choices extends Component
                             isDisabled: {{ json_encode($isDisabled()) }},
                             isRequired: {{ json_encode($isRequired()) }},
                             minChars: {{ $minChars }},
-                            searching: false,
-
+                            
                             init() {
                                 // Fix weird issue when navigating back
                                 document.addEventListener('livewire:navigating', () => {
@@ -281,13 +280,13 @@ class Choices extends Component
                                 class="outline-none mt-0.5 bg-transparent w-20"
 
                                 @if($searchable)
-                                    @keydown.debounce.{{ $debounce }}="searching = !!$el.value; search($el.value)"
+                                    @keydown.debounce.{{ $debounce }}="search($el.value)"
                                 @endif
                              />
 
                             <!-- PLACEHOLDER -->
                             @if (!$compact && $attributes->has('placeholder'))
-                                <span @class(["absolute inset-0 mt-2.5 mr-8 truncate text-base text-gray-400 pointer-events-none", $icon ? "ml-10" : "ml-4"]) x-show="isSelectionEmpty && !searching">
+                                <span @class(["absolute inset-0 mt-2.5 me-8 truncate text-base text-gray-400 pointer-events-none", $icon ? "ms-10" : "ms-4"]) x-show="isSelectionEmpty && !focused">
                                     {{ $attributes->get('placeholder') }}
                                 </span>
                             @endif

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -101,6 +101,7 @@ class Choices extends Component
                             isDisabled: {{ json_encode($isDisabled()) }},
                             isRequired: {{ json_encode($isRequired()) }},
                             minChars: {{ $minChars }},
+                            searching: false,
 
                             init() {
                                 // Fix weird issue when navigating back
@@ -280,9 +281,16 @@ class Choices extends Component
                                 class="outline-none mt-0.5 bg-transparent w-20"
 
                                 @if($searchable)
-                                    @keydown.debounce.{{ $debounce }}="search($el.value)"
+                                    @keydown.debounce.{{ $debounce }}="searching = !!$el.value; search($el.value)"
                                 @endif
                              />
+
+                            <!-- PLACEHOLDER -->
+                            @if (!$compact && $attributes->has('placeholder'))
+                                <span @class(["absolute inset-0 mt-2.5 mr-8 truncate text-base text-gray-400 pointer-events-none", $icon ? "ml-10" : "ml-4"]) x-show="isSelectionEmpty && !searching">
+                                    {{ $attributes->get('placeholder') }}
+                                </span>
+                            @endif
                         </div>
 
                         <!-- APPEND -->

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -273,6 +273,13 @@ class ChoicesOffline extends Component
                                 :class="(isReadonly || isDisabled || !isSearchable || !focused) && '!w-1'"
                                 class="outline-none mt-0.5 bg-transparent w-20"
                              />
+
+                            <!-- PLACEHOLDER -->
+                            @if (!$compact && $attributes->has('placeholder'))
+                                <span @class(["absolute inset-0 mt-2.5 mr-8 truncate text-base text-gray-400 pointer-events-none", $icon ? "ml-10" : "ml-4"]) x-show="isSelectionEmpty && !search">
+                                    {{ $attributes->get('placeholder') }}
+                                </span>
+                            @endif
                         </div>
 
 

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -276,7 +276,7 @@ class ChoicesOffline extends Component
 
                             <!-- PLACEHOLDER -->
                             @if (!$compact && $attributes->has('placeholder'))
-                                <span @class(["absolute inset-0 mt-2.5 mr-8 truncate text-base text-gray-400 pointer-events-none", $icon ? "ml-10" : "ml-4"]) x-show="isSelectionEmpty && !search">
+                                <span @class(["absolute inset-0 mt-2.5 me-8 truncate text-base text-gray-400 pointer-events-none", $icon ? "ms-10" : "ms-4"]) x-show="!focused && isSelectionEmpty">
                                     {{ $attributes->get('placeholder') }}
                                 </span>
                             @endif


### PR DESCRIPTION
Adds support for providing `placeholder="Some value"` to Choices and ChoicesOffline. Closes #640.

I tried using the placeholder for the input first but that lead to layout issues so I've added an absolute positioned span instead. I tried to make it look as similar as possible to the input placeholder. 

Because this is a complex component it should be tested with different use-cases. I tested it by adding the placeholder to all cases on the mary-ui.com page for choices. The only not so perfect thing I found was that when searching with the Choices component, the placeholder is removed after the debounce, leading it to overlap with the inputted text for 250ms.

![image](https://github.com/user-attachments/assets/d3e321f5-6dee-44af-941d-51dd0d677e18)
