### PR TITLE
MenuItem: adds icon right and spinner

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -4,7 +4,6 @@ namespace Mary\View\Components;
 
 use Closure;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
@@ -15,7 +14,6 @@ class MenuItem extends Component
     public function __construct(
         public ?string $title = null,
         public ?string $icon = null,
-        public ?string $iconRight = null,
         public ?string $spinner = null,
         public ?string $link = null,
         public ?string $route = null,
@@ -57,7 +55,7 @@ class MenuItem extends Component
             return true;
         }
 
-        return !$this->exact && $this->link != '/' && Str::startsWith($route, $link);
+        return ! $this->exact && $this->link != '/' && Str::startsWith($route, $link);
     }
 
     public function render(): View|Closure|string
@@ -89,19 +87,19 @@ class MenuItem extends Component
                                 wire:navigate
                             @endif
                         @endif
-                        
+
                         @if($spinner)
                             wire:target="{{ $spinnerTarget() }}"
                             wire:loading.attr="disabled"
                         @endif
                     >
-                        <!-- SPINNER LEFT -->
-                        @if($spinner && !$iconRight)
+                        <!-- SPINNER -->
+                        @if($spinner)
                             <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
                         @endif
 
                         @if($icon)
-                            <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
+                            <span class="block -mt-0.5" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
                                 <x-mary-icon :name="$icon" />
                             </span>
                         @endif
@@ -118,17 +116,6 @@ class MenuItem extends Component
                                 {{ $slot }}
                             @endif
                         </span>
-                        @endif
-                        
-                        <!-- ICON RIGHT -->
-                        @if($iconRight)
-                            <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
-                                <x-mary-icon :name="$iconRight" />
-                            </span>
-                        @endif
-                        <!-- SPINNER RIGHT -->
-                        @if($spinner && $iconRight)
-                            <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
                         @endif
                     </a>
                 </li>

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -15,6 +15,8 @@ class MenuItem extends Component
     public function __construct(
         public ?string $title = null,
         public ?string $icon = null,
+        public ?string $iconRight = null,
+        public ?string $spinner = null,
         public ?string $link = null,
         public ?string $route = null,
         public ?bool $external = false,
@@ -27,6 +29,15 @@ class MenuItem extends Component
         public ?bool $exact = false
     ) {
         $this->uuid = "mary" . md5(serialize($this));
+    }
+
+    public function spinnerTarget(): ?string
+    {
+        if ($this->spinner == 1) {
+            return $this->attributes->whereStartsWith('wire:click')->first();
+        }
+
+        return $this->spinner;
     }
 
     public function routeMatches(): bool
@@ -78,9 +89,21 @@ class MenuItem extends Component
                                 wire:navigate
                             @endif
                         @endif
+                        
+                        @if($spinner)
+                            wire:target="{{ $spinnerTarget() }}"
+                            wire:loading.attr="disabled"
+                        @endif
                     >
+                        <!-- SPINNER LEFT -->
+                        @if($spinner && !$iconRight)
+                            <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
+                        @endif
+
                         @if($icon)
-                            <x-mary-icon :name="$icon" />
+                            <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
+                                <x-mary-icon :name="$icon" />
+                            </span>
                         @endif
 
                         @if($title || $slot->isNotEmpty())
@@ -95,6 +118,17 @@ class MenuItem extends Component
                                 {{ $slot }}
                             @endif
                         </span>
+                        @endif
+                        
+                        <!-- ICON RIGHT -->
+                        @if($iconRight)
+                            <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
+                                <x-mary-icon :name="$iconRight" />
+                            </span>
+                        @endif
+                        <!-- SPINNER RIGHT -->
+                        @if($spinner && $iconRight)
+                            <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
                         @endif
                     </a>
                 </li>


### PR DESCRIPTION
`This is my first time contributing to a project, forgive me if I make a mistake, point out the error so I can improve in the future.`


I added support for the **icon on the right**.

I added support for the **spinner** .

When using a Dropdown, for example, and the action takes a few seconds to complete, it is crucial that the user has visual feedback that something is happening.
To obtain the expected result it is necessary to use MenuItem with `wire:click.stop="archive"`

![Captura de tela de 2024-09-27 11-45-32](https://github.com/user-attachments/assets/afc01dfb-7385-4f6a-8de3-85911bccbb27) ![Captura de tela de 2024-09-27 11-45-23](https://github.com/user-attachments/assets/1d87f0cf-69ce-4241-b943-e10a79b0edce)
