### PR TITLE
Revert "MenuItem: add support for modifiers on wire:navigate"

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -75,7 +75,7 @@ class MenuItem extends Component
                             @endif
 
                             @if(!$external && !$noWireNavigate)
-                                {{ $attributes->wire('navigate') }}
+                                wire:navigate
                             @endif
                         @endif
                     >


### PR DESCRIPTION
Reverts robsontenorio/Mary#636

@anfeichtinger Unfortunately I need revert this, because I noticed it breaks the default behavior of menu items that is `wire:navigate`