### PR TITLE
Table: add `no-hover`

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -36,6 +36,7 @@ class Table extends Component
         public ?bool $showEmptyText = false,
         public mixed $emptyText = 'No records found.',
         public string $containerClass = 'overflow-x-auto',
+        public ?bool $noHover = false,
 
         // Slots
         public mixed $actions = null,
@@ -299,7 +300,7 @@ class Table extends Component
                             @foreach($rows as $k => $row)
                                 <tr
                                     wire:key="{{ $uuid }}-{{ $k }}"
-                                    class="hover:bg-base-200/50 {{ $rowClasses($row) }}"
+                                    @class([$rowClasses($row), "hover:bg-base-200/50" => !$noHover])
                                     @if($attributes->has('@row-click'))
                                         @click="$dispatch('row-click', {{ json_encode($row) }});"
                                     @endif


### PR DESCRIPTION
Disable hover effect on rows. Close #635 

<img width="882" alt="image" src="https://github.com/user-attachments/assets/7d4d4708-66e2-4606-85b7-94af9df3717e">
