### PR TITLE
feat: live mode for datepicker range mode

### DIFF
--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -18,6 +18,7 @@ class DatePicker extends Component
         public ?string $hint = null,
         public ?string $hintClass = 'label-text-alt text-gray-400 py-1 pb-0',
         public ?bool $inline = false,
+        public ?bool $live = false,
         public ?array $config = [],
         // Validations
         public ?string $errorField = null,
@@ -60,7 +61,6 @@ class DatePicker extends Component
 
         // Sets default date as current bound model
         $config = str_replace('"#model#"', '$wire.get("' . $this->modelName() . '")', $config);
-
         return $config;
     }
 
@@ -85,6 +85,9 @@ class DatePicker extends Component
                         <div
                             x-data="{instance: undefined}"
                             x-init="instance = flatpickr($refs.input, {{ $setup() }});"
+                            @if($live && $config["mode"] == "range")
+                                x-on:change="const value = $event.target.value; if(value.split('to').length == 2) {$wire.set('{{ $modelName() }}', value)};"
+                            @endif
                             x-on:livewire:navigating.window="instance.destroy();"
                         >
                             <input


### PR DESCRIPTION
Using `wire:model.live` makes datepicker with mode set to `range` behave unexpectedly as described in #649. This is due to livewire sending update as long as the user selects the first date. I can't find anyway to customize the behavior of livewire's `.live` modefier. My proposed fix for instances when you want live update as long as the user selects a range is to add a `live` attribute to datepicker. This will add a change event listener using `x-on:change` which checks if the date is complete by spliting it with `'to'` and checking if the resulting array contains two items. The listener only gets attached if the mode is set to range, hence making the `live` attribute range mode exclusive.