### PR TITLE
MenuItem: add support for modifiers on wire:navigate

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -84,7 +84,7 @@ class MenuItem extends Component
                             @endif
 
                             @if(!$external && !$noWireNavigate)
-                                wire:navigate
+                                {{ $attributes->wire('navigate')->value() ? $attributes->wire('navigate') : 'wire:navigate' }}
                             @endif
                         @endif
 


### PR DESCRIPTION
After the initial PR had a bug and had to be reverted in #651, here is the fixed version. Here are the use cases I tested with the results. Let me know if there is something I missed or a wrong behaviour.

Code:
```blade
<x-menu class="border border-dashed">
    <!-- Should have wire:navigate.hover -->
    <x-menu-item title="Hover link" icon="o-eye" link="/docs/components/alert" wire:navigate.hover />

    <!-- Should have wire:navigate -->
    <x-menu-item title="Default link" icon="o-arrow-down" link="/docs/components/alert" />

    <!-- Should have wire:navigate -->
    <x-menu-item title="With navigate" icon="o-map-pin" link="/docs/components/alert" wire:navigate />

    <!-- Should not have wire:navigate -->
    <x-menu-item title="External link" icon="o-arrow-uturn-right" link="https://google.com" external />

    <!-- Should not have wire:navigate -->
    <x-menu-item title="Internal without wire:navigate" icon="o-power" link="/docs/components/menu" no-wire-navigate />
</x-menu>
```

Result \<a\> tag in html:
```blade
<!-- Should have wire:navigate.hover -->
<a class="my-0.5 hover:text-inherit rounded-md whitespace-nowrap" wire:navigate.hover href="/docs/components/alert">

<!-- Should have wire:navigate -->
<a class="my-0.5 hover:text-inherit rounded-md whitespace-nowrap" href="/docs/components/alert" wire:navigate>

<!-- Should have wire:navigate -->
<a class="my-0.5 hover:text-inherit rounded-md whitespace-nowrap" wire:navigate href="/docs/components/alert">

<!-- Should not have wire:navigate -->
<a class="my-0.5 hover:text-inherit rounded-md whitespace-nowrap" href="https://google.com" target="_blank">

<!-- Should not have wire:navigate -->
<a class="my-0.5 hover:text-inherit rounded-md whitespace-nowrap" href="/docs/components/menu">
```

Result image:
![image](https://github.com/user-attachments/assets/0c3728bd-455a-4e30-87a7-c78a37eb0f79)