### PR TITLE
Checkbox: allow appending a custom id to the uuid

### DIFF
--- a/src/View/Components/Checkbox.php
+++ b/src/View/Components/Checkbox.php
@@ -11,6 +11,7 @@ class Checkbox extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'label-text-alt text-gray-400 py-1 pb-0',
@@ -23,7 +24,7 @@ class Checkbox extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -43,7 +44,7 @@ class Checkbox extends Component
                     <label for="{{ $uuid }}" class="flex gap-3 items-center cursor-pointer">
                         @if($right)
                             <span @class(["flex-1" => !$tight])>
-                                {{ $label}}
+                                {{ $label }}
 
                                 @if($attributes->get('required'))
                                     <span class="text-error">*</span>
@@ -52,12 +53,12 @@ class Checkbox extends Component
                         @endif
 
                         <input
+                            id="{{ $uuid }}"
                             type="checkbox"
-                            {{ $attributes->whereDoesntStartWith('class') }}
-                            {{ $attributes->merge(["id" => $uuid])->class(['checkbox checkbox-primary']) }}  />
+                            {{ $attributes->whereDoesntStartWith('id')->merge(['class' => 'checkbox checkbox-primary']) }}  />
 
                         @if(!$right)
-                            {{ $label}}
+                            {{ $label }}
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>


### PR DESCRIPTION
Closes #643.

> I think we can go like this :
> 
> `$this->uuid = "mary" . md5(serialize($this)). $this->id;`
>
> So, won’t be conflict if others components has the same id.

Allows passing a custom id to the checkbox component so the uuid can be different in case other parameters are the same.

The following component calls:
```blade
<!-- No id -->
<x-checkbox label="X" wire:model="item1" />

<!-- Id "test1" -->
<x-checkbox label="X" wire:model="item1" id="test1" />

<!-- Id "test2" -->
<x-checkbox label="X" wire:model="item2" id="test2" />
```


Lead to the following uuids (rendered as label so it is easier to show in the example)
![image](https://github.com/user-attachments/assets/5a954308-d8e9-4e44-b7a3-8cd2b1b1c03f)

Note: Just providing the id will also lead to a completely different hash anyways so maybe we don't even need to append it.
