### PR TITLE
Swap: introduce as new component

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -64,6 +64,7 @@ use Mary\View\Components\Spotlight;
 use Mary\View\Components\Stat;
 use Mary\View\Components\Step;
 use Mary\View\Components\Steps;
+use Mary\View\Components\Swap;
 use Mary\View\Components\Tab;
 use Mary\View\Components\Table;
 use Mary\View\Components\Tabs;
@@ -170,6 +171,7 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'stat', Stat::class);
         Blade::component($prefix . 'steps', Steps::class);
         Blade::component($prefix . 'step', Step::class);
+        Blade::component($prefix . 'swap', Swap::class);
         Blade::component($prefix . 'table', Table::class);
         Blade::component($prefix . 'tab', Tab::class);
         Blade::component($prefix . 'tabs', Tabs::class);

--- a/src/View/Components/Swap.php
+++ b/src/View/Components/Swap.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Mary\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Swap extends Component
+{
+    public string $uuid;
+
+    public function __construct(
+        public ?string $id = null,
+        public ?string $true = null,
+        public ?string $false = null,
+        public ?string $trueIcon = 'o-sun',
+        public ?string $falseIcon = 'o-moon',
+        public ?string $iconSize = "h-5 w-5",
+    ) {
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
+    }
+
+    public function render(): View|Closure|string
+    {
+        return <<<'BLADE'
+                <label
+                    for="{{ $uuid }}"
+                    {{ $attributes->whereDoesntStartWith('wire:model') }}>
+
+                    {{-- Before --}}
+                    @isset ($before)
+                        <div {{ $before->attributes }}>
+                            {{ $before }}
+                        </div>
+                    @endif
+
+                    <div class="swap">
+
+                        {{-- Hidden checkbox for state --}}
+                        <input id="{{ $uuid }}" type="checkbox" {{ $attributes->wire('model') }} />
+
+                        {{-- True Element --}}
+                        @isset ($true)
+                            <div {{ is_string($true) ? new Illuminate\View\ComponentAttributeBag(['class' => 'swap-on']) : $true->attributes->merge(['class' => 'swap-on']) }}>
+                                {{ $true ?? '' }}
+                            </div>
+                        @else
+                            <x-mary-icon :name="$trueIcon" class="swap-on {{ $iconSize }}" />
+                        @endif
+
+                        {{-- False Element --}}
+                        @isset ($false)
+                        <div {{ is_string($false) ? new Illuminate\View\ComponentAttributeBag(['class' => 'swap-off']) : $false->attributes->merge(['class' => 'swap-off']) }}>
+                                {{ $false ?? '' }}
+                            </div>
+                        @else 
+                            <x-mary-icon :name="$falseIcon" class="swap-off {{ $iconSize }}" />
+                        @endif
+
+                    </div>
+
+                    {{-- After --}}
+                    @isset ($after)
+                        <div {{ $after->attributes }}>
+                            {{ $after }}
+                        </div>
+                    @endif
+                </label>
+            BLADE;
+    }
+}


### PR DESCRIPTION
This will add a new component Swap, built to simplify [daisy-ui's swap functionality](https://daisyui.com/components/swap/).
Currently we only have the theme toggle which is probably the most common use case for swapping, but it is limited to swapping the current theme. With this you can swap any content. Here are some examples:

```blade
{{-- Default works without model and uses theme toggle icons --}}
<x-swap />

{{-- wire:model + custom icons + flip animation + custom size --}}
<x-swap wire:model="rating" true-icon="o-speaker-wave" false-icon="o-speaker-x-mark"
             icon-size="h-8 w-8" class="swap-flip" />

{{-- wire:model.live + simple text content (size and color can be customized by using a parent element) --}}
<x-swap wire:model.live="rating" true="ON" false="OFF" />

{{-- Completely custom content --}}
<x-swap>
    
    {{-- True--}}
    <x-slot:true
        class="h-12 p-2 bg-primary text-primary-content rounded-2xl flex flex-row items-center justify-center">
            Custom on
    </x-slot:true>

    {{-- False--}}
    <x-slot:false
        class="h-12 p-2 bg-error text-error-content rounded flex flex-row items-center justify-center">
            Custom off
    </x-slot:false>

</x-swap>

{{-- Before and after slots --}}
<x-swap wire:model.live="rating" class="flex flex-row space-x-2 w-fit">

    {{-- Before --}}
    <x-slot:before class="text-primary">
        Swap me!
    </x-slot:before>

    {{-- After --}}
    <x-slot:after class="text-error">
        {{ $this->rating ? 'ON' : 'OFF' }}
    </x-slot:after>

</x-swap>
```

It is kind of hard to showcase as there are animations involved but here are the above examples in their true and false states as screenshots:

True             |  False
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/8ca02004-f77b-436b-8586-020dd7cf1959)  |  ![image](https://github.com/user-attachments/assets/d2cc132e-c482-4b8a-b093-d5b90d71fc26)

Note: The indeterminate state is currently not supported as it can only be set via javascript. If it is implemented we could switch between 3 states.