### PR TITLE
Improve Table Selectable

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -198,7 +198,7 @@ class Table extends Component
                                     return this.selection.includes(key)
                                 },
                                 isPageFullSelected() {
-                                    return this.pageIds.length && && [...this.selection]
+                                    return this.pageIds.length && [...this.selection]
                                                 .sort((a, b) => b - a)
                                                 .toString()
                                                 .includes([...this.pageIds].sort((a, b) => b - a).toString())

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -198,7 +198,7 @@ class Table extends Component
                                     return this.selection.includes(key)
                                 },
                                 isPageFullSelected() {
-                                    return [...this.selection]
+                                    return this.pageIds.length && && [...this.selection]
                                                 .sort((a, b) => b - a)
                                                 .toString()
                                                 .includes([...this.pageIds].sort((a, b) => b - a).toString())
@@ -254,6 +254,7 @@ class Table extends Component
                                             type="checkbox"
                                             class="checkbox checkbox-sm"
                                             x-ref="mainCheckbox"
+                                            x-bind:disabled="pageIds.length === 0"
                                             @click="toggleCheckAll($el.checked)" />
                                     </th>
                                 @endif


### PR DESCRIPTION
When a table is empty, the SelectAll checkbox is always active.

This commit disables and uncheck SelectAll checkbox for a better UI experience.

Before
![image](https://github.com/user-attachments/assets/329b6dc4-ee94-4f09-82bc-f5eb41b5d23f)

After
![image](https://github.com/user-attachments/assets/131f8473-9da8-4f0d-8725-8dae08b52cff)
