### PR TITLE
Add close button to Modal component

### DIFF
--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -40,6 +40,15 @@ class Modal extends Component
                     @endif
                 >
                     <div class="modal-box {{ $boxClass }}">
+                        @if(!$persistent)
+                            <form method="dialog">
+                                @if ($id)
+                                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" type="submit">✕</button>
+                                @else
+                                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" @click="$wire.{{ $attributes->wire('model')->value() }} = false" type="button">✕</button>
+                                @endif
+                            </form>
+                        @endif
                         @if($title)
                             <x-mary-header :title="$title" :subtitle="$subtitle" size="text-2xl" :separator="$separator" class="mb-5" />
                         @endif

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -43,9 +43,9 @@ class Modal extends Component
                         @if(!$persistent)
                             <form method="dialog">
                                 @if ($id)
-                                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" type="submit">✕</button>
+                                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 font-bold text-xl" type="submit">✕</button>
                                 @else
-                                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" @click="$wire.{{ $attributes->wire('model')->value() }} = false" type="button">✕</button>
+                                    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 font-bold text-xl" @click="$wire.{{ $attributes->wire('model')->value() }} = false" type="button">✕</button>
                                 @endif
                             </form>
                         @endif


### PR DESCRIPTION
Introduce a close button inside the modal box. The button supports both form submissions and live wire updates, depending on the presence of an ID, enhancing the modal's usability and user experience.

<img width="526" alt="image" src="https://github.com/user-attachments/assets/1e2dc1f9-fa7b-4fcb-9361-d3bf0dc4ec68">
