### PR TITLE
Use TinyMCE with the GPLv2+ license

### DIFF
--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -18,6 +18,7 @@ class Editor extends Component
         public ?string $hintClass = 'label-text-alt text-gray-400 ps-1 mt-2',
         public ?string $disk = 'public',
         public ?string $folder = 'editor',
+        public ?bool $gplLicense = false,
         public ?array $config = [],
         // Validations
         public ?string $errorField = null,
@@ -89,6 +90,11 @@ class Editor extends Component
                         x-init="
                             tinymce.init({
                                 {{ $setup() }},
+
+                                @if($gplLicense)
+                                    license_key: 'gpl',
+                                @endif
+            
                                 target: $refs.tinymce,
                                 images_upload_url: uploadUrl,
                                 readonly: {{ json_encode($attributes->get('readonly') || $attributes->get('disabled')) }},


### PR DESCRIPTION
If the developer intends to self-host TinyMCE under the GPL license, they can set the license_key config option to 'gpl'.

With this change, you can add a setting to use a GPL licence by using gpl-licence ="true".

<x-mary-editor wire:model="text" gpl-license="true" label="Description" hint="The full product description" />
