### PR TITLE
Added member variable for  so that it renders when used with MenuItem

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -24,7 +24,10 @@ class MenuItem extends Component
         public ?bool $active = false,
         public ?bool $separator = false,
         public ?bool $enabled = true,
-        public ?bool $exact = false
+        public ?bool $exact = false,
+
+        // Slot
+        public mixed $slot = null,
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }


### PR DESCRIPTION
Simply added the $slot variable to MenuItem.php so that the $slot can actually be used.

Carrying on the way the variable is named in the class already, usage looks like this:

```
<x-menu-item>
     <x-slot:slot> Slot Content </x-slot:slot>
</x-menu-item>
```