### PR TITLE
Refactor Tab component to add support for disabling tabs

### DIFF
--- a/src/View/Components/Tab.php
+++ b/src/View/Components/Tab.php
@@ -29,7 +29,7 @@ class Tab extends Component
                 <x-mary-icon name='" . $this->icon . "' @class([
                 'me-2',
                 'whitespace-nowrap',
-                'text-gray-600 border-b-gray-600 dark: text-base-300 border-b-base-300 cursor-not-allowed' => '$this->disabled'
+                'text-base-content/30 cursor-not-allowed' => '$this->disabled'
                 ])>
                     <x-slot:label>
                         {$fromLabel}
@@ -41,7 +41,7 @@ class Tab extends Component
         return Blade::render("
             <div @class([
                 'whitespace-nowrap',
-                'text-gray-600 border-b-gray-600 dark: text-base-300 border-b-base-300 cursor-not-allowed' => '$this->disabled'
+                'text-base-content/30 cursor-not-allowed' => '$this->disabled'
                 ])>
                 {$fromLabel}
             </div>

--- a/src/View/Components/Tab.php
+++ b/src/View/Components/Tab.php
@@ -14,7 +14,8 @@ class Tab extends Component
     public function __construct(
         public ?string $name = null,
         public ?string $label = null,
-        public ?string $icon = null
+        public ?string $icon = null,
+        public bool $disabled = false,
     ) {
         $this->uuid = "mary" . md5(serialize($this));
     }
@@ -25,7 +26,11 @@ class Tab extends Component
 
         if ($this->icon) {
             return Blade::render("
-                <x-mary-icon name='" . $this->icon . "' class='me-2 whitespace-nowrap'>
+                <x-mary-icon name='" . $this->icon . "' @class([
+                'me-2',
+                'whitespace-nowrap',
+                'text-gray-600 border-b-gray-600 dark: text-base-300 border-b-base-300 cursor-not-allowed' => '$this->disabled'
+                ])>
                     <x-slot:label>
                         {$fromLabel}
                     </x-slot:label>
@@ -34,7 +39,10 @@ class Tab extends Component
         }
 
         return Blade::render("
-            <div class='whitespace-nowrap'>
+            <div @class([
+                'whitespace-nowrap',
+                'text-gray-600 border-b-gray-600 dark: text-base-300 border-b-base-300 cursor-not-allowed' => '$this->disabled'
+                ])>
                 {$fromLabel}
             </div>
         ");
@@ -48,7 +56,7 @@ class Tab extends Component
                         :class="{ 'tab-active': selected === '{{ $name }}' }"
                         data-name="{{ $name }}"
                         x-init="
-                                const newItem = { name: '{{ $name }}', label: {{ json_encode($tabLabel($label)) }} };
+                                const newItem = { name: '{{ $name }}', label: {{ json_encode($tabLabel($label)) }}, disabled: {{ $disabled ? 'true' : 'false' }} };
                                 const index = tabs.findIndex(item => item.name === '{{ $name }}');
                                 index !== -1 ? tabs[index] = newItem : tabs.push(newItem);
 

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -49,7 +49,7 @@ class Tabs extends Component
                                 <a
                                     role="tab"
                                     x-html="tab.label"
-                                    @click="selected = tab.name"
+                                     @click="tab.disabled ? null: selected = tab.name"
                                     :class="(selected === tab.name) && '{{ $activeClass }}'"
                                     class="tab {{ $labelClass }}"></a>
                             </template>


### PR DESCRIPTION
This pull request adds support for disabling tabs in the x-tabs component, allowing certain tabs to be visually disabled and preventing user interaction.

The code bellow:
```blade
<x-tabs wire:model.live="person">
  <x-tab name="np" label="Pessoa Física" icon="o-users" disabled>
    ...
  </x-tab>
  <x-tab name="lp" label="Pessoa Jurídica" icon="o-building-office-2">
    ...
  </x-tab>
</x-tabs>
```
will generate this effect:

![image](https://github.com/user-attachments/assets/ae4efe3f-454a-4314-b5a2-03f37414e220)

When click disabled tab, nothing happens.