### PR TITLE
feat: make input inside a modal autofucosable

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -21,6 +21,7 @@ class Input extends Component
         public ?bool $inline = false,
         public ?bool $clearable = false,
         public ?bool $money = false,
+        public ?bool $modalAutofocus = false,
         public ?string $locale = 'en-US',
 
         // Slots
@@ -59,6 +60,8 @@ class Input extends Component
     {
         return <<<'BLADE'
             <div>
+                
+                
                 @php
                     // Wee need this extra step to support models arrays. Ex: wire:model="emails.0"  , wire:model="emails.1"
                     $uuid = $uuid . $modelName()
@@ -108,9 +111,14 @@ class Input extends Component
 
                     {{-- INPUT --}}
                     <input
+                        @if($modalAutofocus)
+                            x-ref="myInput"
+                            @focus-me.window="$refs.myInput.focus();"
+                        @endif
                         id="{{ $uuid }}"
                         placeholder = "{{ $attributes->whereStartsWith('placeholder')->first() }} "
-
+                                
+                                
                         @if($money)
                             x-ref="myInput"
                             :value="amount"

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -15,6 +15,7 @@ class Modal extends Component
         public ?string $boxClass = null,
         public ?bool $separator = false,
         public ?bool $persistent = false,
+        public ?bool $focusEvent = false,
 
         // Slots
         public ?string $actions = null
@@ -27,7 +28,11 @@ class Modal extends Component
         return <<<'HTML'
                 <dialog
                     {{ $attributes->except('wire:model')->class(["modal"]) }}
-
+                    
+                    @if($focusEvent)
+                        x-init="$watch('open', (value) => {  $dispatch('focus-me'); })" 
+                    @endif
+                    
                     @if($id)
                         id="{{ $id }}"
                     @else


### PR DESCRIPTION
This commit makes an input inside a modal autofocusable by adding the `focus_event` attribute to the modal and `modal_autofocus` attribute to the input which should be focused. This has to be done as the autofocus HTML attribute only sets focus for inputs that are visible on page load which are not the case for most modal.

closes #683 