### PR TITLE
Progress: support for decimals

### DIFF
--- a/src/View/Components/Progress.php
+++ b/src/View/Components/Progress.php
@@ -11,8 +11,8 @@ class Progress extends Component
     public string $uuid;
 
     public function __construct(
-        public ?int $value = 0,
-        public ?int $max = 100,
+        public ?float $value = 0,
+        public ?float $max = 100,
         public ?bool $indeterminate = false,
 
     ) {


### PR DESCRIPTION
When there is a decimal value such as "10.5", the progress bar will be able to assign its decimal fraction to it, instead of considering only the integral part of that number.