### PR TITLE
Main: use `persist` approach for sidebar state

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,12 +4,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 
-Route::middleware('web')->prefix(config('mary.route_prefix'))->get('/mary/toogle-sidebar', function (Request $request) {
-    if ($request->collapsed) {
-        session(['mary-sidebar-collapsed' => $request->collapsed]);
-    }
-})->name('mary.toogle-sidebar');
-
 Route::middleware('web')->prefix(config('mary.route_prefix'))->get('/mary/spotlight', function (Request $request) {
     return app()->make(config('mary.components.spotlight.class'))->search($request);
 })->name('mary.spotlight');

--- a/src/View/Components/Main.php
+++ b/src/View/Components/Main.php
@@ -11,7 +11,6 @@ class Main extends Component
     public string $url;
 
     public function __construct(
-
         // Slots
         public mixed $sidebar = null,
         public mixed $content = null,
@@ -44,11 +43,10 @@ class Main extends Component
                         @if($sidebar)
                             <div
                                 x-data="{
-                                    collapsed: {{ session('mary-sidebar-collapsed', 'false') }},
+                                    collapsed: $persist('{{ session('mary-sidebar-collapsed', 'false') }}' === 'true'),
                                     collapseText: '{{ $collapseText }}',
                                     toggle() {
                                         this.collapsed = !this.collapsed;
-                                        fetch('{{ $url }}?collapsed=' + this.collapsed);
                                         this.$dispatch('sidebar-toggled', this.collapsed);
                                     }
                                 }"


### PR DESCRIPTION
removing redundant code, there is no need to call fetch and run the whole event via $wire, now it is no longer needed, $persists from Alpine JS was used and the whole event works better
