### PR TITLE
FEATURE | Radio - New label option to integrate HTML

### DIFF
--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -13,6 +13,7 @@ class Radio extends Component
 
     public function __construct(
         public ?string $label = null,
+        public ?string $labelHtml = null,
         public ?string $hint = null,
         public ?string $hintClass = 'label-text-alt text-gray-400 ps-1 mt-2',
         public ?string $optionValue = 'id',
@@ -41,6 +42,11 @@ class Radio extends Component
     {
         return <<<'HTML'
                 <div>
+                    @if($labelHtml)
+                        <div class="pt-0 pb-2 label-text font-semibold">
+                            {!! \Illuminate\Support\Facades\Blade::render($labelHtml) !!}
+                        </div>
+                    @endif
                     @if($label)
                         <div class="pt-0 label label-text font-semibold">
                             <span>


### PR DESCRIPTION
I added the possibility of passing HTML in the option label.

```PHP
<x-code>
        @verbatim('docs')
            @php
                $users = App\Models\User::take(3)->get();
                $labelHtml = "<x-popover>
                    <x-slot:trigger>
                        <x-icon name='o-information-circle'/> Select one
                    </x-slot:trigger>
                    <x-slot:content>
                        HEY, this is a suggestion
                    </x-slot:content>
                </x-popover>";
            @endphp
            <x-radio
                :labelHtml=$labelHtml
                :options="$users"
                wire:model="selectedUser3" />
        @endverbatim
    </x-code>
```