### PR TITLE
Fix for pagination "onEachSide"

### DIFF
--- a/src/View/Components/Pagination.php
+++ b/src/View/Components/Pagination.php
@@ -46,7 +46,7 @@ class Pagination extends Component
                     </div>
                     @endif
                     <div class="w-full">
-                    @if($rows instanceof LengthAwarePaginator)
+                    @if($rows instanceof Illuminate\Contracts\Pagination\LengthAwarePaginator)
                         {{ $rows->onEachSide(1)->links(data: ['scrollTo' => false]) }}
                     @else
                         {{ $rows->links(data: ['scrollTo' => false]) }}


### PR DESCRIPTION
`$rows->onEachSide(1)` was not working as expected in my project. Seems we have to use the full qualified namespace in the template for this to work:

<img width="498" alt="before" src="https://github.com/user-attachments/assets/a61c618a-1057-48b7-ad0c-24b4e8132b81">
<img width="440" alt="after" src="https://github.com/user-attachments/assets/5740da20-a925-4f21-a6a5-cfb0b7edd986">
