### PR TITLE
File/ImageLibrary: handle focus trap

### DIFF
--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -198,7 +198,7 @@ class File extends Component
 
                         <!-- CROP MODAL -->
                         <div @click.prevent="" x-ref="crop" wire:ignore>
-                            <x-mary-modal id="maryCrop{{ $uuid }}" x-ref="maryCrop" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="">
+                            <x-mary-modal id="maryCrop{{ $uuid }}" x-ref="maryCrop" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="" without-trap-focus>
                                 <img src="" />
                                 <x-slot:actions>
                                     <x-mary-button :label="$cropCancelText" @click="close()" />

--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -185,7 +185,7 @@ class ImageLibrary extends Component
 
                     <!-- CROP MODAL -->
                     <div @click.prevent="" x-ref="crop" wire:ignore>
-                        <x-mary-modal id="maryCropModal{{ $uuid }}" x-ref="maryCropModal" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="">
+                        <x-mary-modal id="maryCropModal{{ $uuid }}" x-ref="maryCropModal" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="" without-trap-focus>
                             <img src="#" crossOrigin="Anonymous" />
                             <x-slot:actions>
                                 <x-mary-button :label="$cropCancelText" @click="close()" />


### PR DESCRIPTION
Disable focus trap, once it uses `native` model.