### PR TITLE
"Fix select class usage to align with daisyUI's recommendation"

### DIFF
--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -86,7 +86,7 @@ class Select extends Component
                             <label
                                 {{
                                     $attributes->whereStartsWith('class')->class([
-                                        "select w-full",
+                                        "w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                         "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
@@ -105,7 +105,7 @@ class Select extends Component
                                 @endif
 
                                 {{-- SELECT --}}
-                                <select id="{{ $uuid }}" {{ $attributes->whereDoesntStartWith('class') }}>
+                                <select id="{{ $uuid }}" class="select" {{ $attributes->whereDoesntStartWith('class') }}>
                                     @if($placeholder)
                                         <option value="{{ $placeholderValue }}">{{ $placeholder }}</option>
                                     @endif

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -89,7 +89,6 @@ class Select extends Component
                                         "w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
-                                        "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
                                     ])
                                 }}
                              >
@@ -105,7 +104,14 @@ class Select extends Component
                                 @endif
 
                                 {{-- SELECT --}}
-                                <select id="{{ $uuid }}" class="select" {{ $attributes->whereDoesntStartWith('class') }}>
+                                <select id="{{ $uuid }}" {{ $attributes->whereDoesntStartWith('class') }} 
+                                {{
+                                    $attributes->whereStartsWith('class')->class([
+                                        "select",
+                                        "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
+                                    ])
+                                }}
+                                >
                                     @if($placeholder)
                                         <option value="{{ $placeholderValue }}">{{ $placeholder }}</option>
                                     @endif


### PR DESCRIPTION
"Fix to match the intended usage of daisyUI.
Instead of adding the select class to the label tag, apply the select class to the select tag."


## before
![image](https://github.com/user-attachments/assets/411d090c-8d1e-4f0b-b18f-30342f6344e9)


## after
![image](https://github.com/user-attachments/assets/97fb649f-02f5-41f5-9b96-cb8fa0bd9258)
