### PR TITLE
Add public `$id` property to all constructors where an `$uuid` property exists

### DIFF
--- a/src/View/Components/Accordion.php
+++ b/src/View/Components/Accordion.php
@@ -11,9 +11,10 @@ class Accordion extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?bool $noJoin = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Alert.php
+++ b/src/View/Components/Alert.php
@@ -19,6 +19,7 @@ class Alert extends Component
      * @slot  mixed  $actions  Slots for actionable elements like buttons or links.
      */
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
         public ?string $description = null,
@@ -28,7 +29,7 @@ class Alert extends Component
         // Slots
         public mixed $actions = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Avatar.php
+++ b/src/View/Components/Avatar.php
@@ -20,6 +20,7 @@ class Avatar extends Component
      * @slot  ?string  $subtitle The subtitle text displayed beside the avatar.
      */
     public function __construct(
+        public ?string $id = null,
         public ?string $image = '',
         public ?string $alt = '',
         public ?string $placeholder = '',
@@ -29,7 +30,7 @@ class Avatar extends Component
         public ?string $subtitle = null
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Badge.php
+++ b/src/View/Components/Badge.php
@@ -11,10 +11,11 @@ class Badge extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $value = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -13,6 +13,7 @@ class Button extends Component
     public string $tooltipPosition = 'lg:tooltip-top';
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -28,7 +29,7 @@ class Button extends Component
         public ?string $tooltipRight = null,
         public ?string $tooltipBottom = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
         $this->tooltip = $this->tooltip ?? $this->tooltipLeft ?? $this->tooltipRight ?? $this->tooltipBottom;
         $this->tooltipPosition = $this->tooltipLeft ? 'lg:tooltip-left' : ($this->tooltipRight ? 'lg:tooltip-right' : ($this->tooltipBottom ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }

--- a/src/View/Components/Calendar.php
+++ b/src/View/Components/Calendar.php
@@ -13,6 +13,7 @@ class Calendar extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?int $months = 1,
         public ?string $locale = 'en-EN',
         public ?bool $weekendHighlight = false,
@@ -20,7 +21,7 @@ class Calendar extends Component
         public ?array $config = [],
         public ?array $events = [],
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function setup(): string

--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -11,6 +11,7 @@ class Card extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $subtitle = null,
         public ?bool $separator = false,
@@ -22,7 +23,7 @@ class Card extends Component
         public mixed $actions = null,
         public mixed $figure = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function progressTarget(): ?string

--- a/src/View/Components/Carousel.php
+++ b/src/View/Components/Carousel.php
@@ -15,6 +15,7 @@ class Carousel extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public array $slides,
         public ?bool $withoutIndicators = false,
         public ?bool $withoutArrows = false,
@@ -22,7 +23,7 @@ class Carousel extends Component
         // Slots
         public mixed $content = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Chart.php
+++ b/src/View/Components/Chart.php
@@ -10,9 +10,10 @@ class Chart extends Component
 {
     public string $uuid;
 
-    public function __construct()
-    {
-        $this->uuid = "mary" . md5(serialize($this));
+    public function __construct(
+        public ?string $id = null,
+    ) {
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -13,6 +13,7 @@ class Choices extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -54,7 +55,7 @@ class Choices extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
 
         if (($this->allowAll || $this->compact) && ($this->single || $this->searchable)) {
             throw new Exception("`allow-all` and `compact` does not work combined with `single` or `searchable`.");

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -13,6 +13,7 @@ class ChoicesOffline extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -53,7 +54,7 @@ class ChoicesOffline extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
 
         if (($this->allowAll || $this->compact) && ($this->single || $this->searchable)) {
             throw new Exception("`allow-all` and `compact` does not work combined with `single` or `searchable`.");

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -11,6 +11,7 @@ class Collapse extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $name = null,
         public ?bool $collapsePlusMinus = false,
         public ?bool $separator = false,
@@ -20,7 +21,7 @@ class Collapse extends Component
         public mixed $heading = null,
         public mixed $content = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Colorpicker.php
+++ b/src/View/Components/Colorpicker.php
@@ -11,6 +11,7 @@ class Colorpicker extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = '',
         public ?string $iconRight = null,
@@ -28,7 +29,7 @@ class Colorpicker extends Component
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -12,6 +12,7 @@ class DatePicker extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -30,7 +31,7 @@ class DatePicker extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/DateTime.php
+++ b/src/View/Components/DateTime.php
@@ -11,6 +11,7 @@ class DateTime extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -29,7 +30,7 @@ class DateTime extends Component
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Diff.php
+++ b/src/View/Components/Diff.php
@@ -12,12 +12,13 @@ class Diff extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public string $old = '',
         public string $new = '',
         public string $fileName = 'payload.json',
         public ?array $config = []
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function setup(): string

--- a/src/View/Components/Drawer.php
+++ b/src/View/Components/Drawer.php
@@ -24,7 +24,7 @@ class Drawer extends Component
         //Slots
         public ?string $actions = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function id(): string

--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -11,6 +11,7 @@ class Dropdown extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = 'o-chevron-down',
         public ?bool $right = false,
@@ -19,7 +20,7 @@ class Dropdown extends Component
         // Slots
         public mixed $trigger = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -21,14 +21,14 @@ class Editor extends Component
         public ?string $folder = 'editor',
         public ?bool $gplLicense = false,
         public ?array $config = [],
-        
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
         $this->uploadUrl = route('mary.upload', absolute: false);
     }
 

--- a/src/View/Components/Errors.php
+++ b/src/View/Components/Errors.php
@@ -11,13 +11,13 @@ class Errors extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $description = null,
         public ?string $icon = 'o-x-circle',
         public ?array $only = [],
-
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -11,6 +11,7 @@ class File extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -30,7 +31,7 @@ class File extends Component
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Group.php
+++ b/src/View/Components/Group.php
@@ -12,6 +12,7 @@ class Group extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -25,7 +26,7 @@ class Group extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Hr.php
+++ b/src/View/Components/Hr.php
@@ -11,9 +11,10 @@ class Hr extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $target = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function progressTarget(): ?string

--- a/src/View/Components/Icon.php
+++ b/src/View/Components/Icon.php
@@ -13,10 +13,11 @@ class Icon extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public string $name,
         public ?string $label = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function icon(): string|Stringable

--- a/src/View/Components/ImageGallery.php
+++ b/src/View/Components/ImageGallery.php
@@ -11,12 +11,13 @@ class ImageGallery extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public array $images,
         public ?bool $withArrows = false,
         public ?bool $withIndicators = false
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -14,6 +14,7 @@ class ImageLibrary extends Component
     public string $mimes = 'image/png, image/jpeg';
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?bool $hideErrors = false,
@@ -29,7 +30,7 @@ class ImageLibrary extends Component
         public Collection $preview = new Collection(),
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -11,6 +11,7 @@ class Input extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -33,7 +34,7 @@ class Input extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Kbd.php
+++ b/src/View/Components/Kbd.php
@@ -11,9 +11,9 @@ class Kbd extends Component
     public string $uuid;
 
     public function __construct(
-
+        public ?string $id = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/ListItem.php
+++ b/src/View/Components/ListItem.php
@@ -11,6 +11,7 @@ class ListItem extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public object|array $item,
         public string $avatar = 'avatar',
         public string $value = 'name',
@@ -22,7 +23,7 @@ class ListItem extends Component
         // Slots
         public mixed $actions = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Loading.php
+++ b/src/View/Components/Loading.php
@@ -10,9 +10,10 @@ class Loading extends Component
 {
     public string $uuid;
 
-    public function __construct()
-    {
-        $this->uuid = "mary" . md5(serialize($this));
+    public function __construct(
+        public ?string $id = null,
+    ) {
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -13,6 +13,7 @@ class Markdown extends Component
     public string $uploadUrl;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -26,7 +27,7 @@ class Markdown extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
         $this->uploadUrl = route('mary.upload', absolute: false);
     }
 
@@ -48,10 +49,23 @@ class Markdown extends Component
             'uploadImage' => true,
             'imageAccept' => 'image/png, image/jpeg, image/gif, image/avif',
             'toolbar' => [
-                'heading', 'bold', 'italic', 'strikethrough', '|',
-                'code', 'quote', 'unordered-list', 'ordered-list', 'horizontal-rule', '|',
-                'link', 'upload-image', 'table', '|',
-                'preview', 'side-by-side'
+                'heading',
+                'bold',
+                'italic',
+                'strikethrough',
+                '|',
+                'code',
+                'quote',
+                'unordered-list',
+                'ordered-list',
+                'horizontal-rule',
+                '|',
+                'link',
+                'upload-image',
+                'table',
+                '|',
+                'preview',
+                'side-by-side'
             ],
         ], $this->config);
 

--- a/src/View/Components/Menu.php
+++ b/src/View/Components/Menu.php
@@ -11,13 +11,14 @@ class Menu extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
         public ?bool $separator = false,
         public ?bool $activateByRoute = false,
         public ?string $activeBgColor = 'bg-base-300',
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -12,6 +12,7 @@ class MenuItem extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
         public ?string $spinner = null,
@@ -26,7 +27,7 @@ class MenuItem extends Component
         public ?bool $enabled = true,
         public ?bool $exact = false
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function spinnerTarget(): ?string

--- a/src/View/Components/MenuSeparator.php
+++ b/src/View/Components/MenuSeparator.php
@@ -11,10 +11,11 @@ class MenuSeparator extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/MenuSub.php
+++ b/src/View/Components/MenuSub.php
@@ -11,12 +11,13 @@ class MenuSub extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
         public bool $open = false,
         public ?bool $enabled = true,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/MenuTitle.php
+++ b/src/View/Components/MenuTitle.php
@@ -11,10 +11,11 @@ class MenuTitle extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
     ) {
-        $this->uuid = 'mary'.md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Nav.php
+++ b/src/View/Components/Nav.php
@@ -35,4 +35,3 @@ class Nav extends Component
                 HTML;
     }
 }
-

--- a/src/View/Components/Pagination.php
+++ b/src/View/Components/Pagination.php
@@ -13,10 +13,11 @@ class Pagination extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ArrayAccess|array $rows,
         public ?array $perPageValues = [10, 20, 50, 100],
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Password.php
+++ b/src/View/Components/Password.php
@@ -12,6 +12,7 @@ class Password extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -38,7 +39,7 @@ class Password extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
 
         // Cannot use a left icon when password toggle should be shown on the left side.
         if (($this->icon && ! $this->right) && ! $this->onlyPassword) {

--- a/src/View/Components/Pin.php
+++ b/src/View/Components/Pin.php
@@ -11,13 +11,14 @@ class Pin extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public int $size,
         public ?bool $numeric = false,
         public ?bool $hide = false,
         public ?string $hideType = "disc",
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Popover.php
+++ b/src/View/Components/Popover.php
@@ -8,24 +8,24 @@ use Illuminate\View\Component;
 
 class Popover extends Component
 {
-  public string $uuid;
+    public string $uuid;
 
-  public function __construct(
-    public ?string $id = null,
-    public ?string $position = "bottom",
-    public ?string $offset = "10",
+    public function __construct(
+        public ?string $id = null,
+        public ?string $position = "bottom",
+        public ?string $offset = "10",
 
-    // Slots
-    public mixed $trigger = null,
-    public mixed $content = null
+        // Slots
+        public mixed $trigger = null,
+        public mixed $content = null
 
-  ) {
-    $this->uuid = "mary" . md5(serialize($this)) . $id;
-  }
+    ) {
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
+    }
 
-  public function render(): View|Closure|string
-  {
-    return <<<'HTML'
+    public function render(): View|Closure|string
+    {
+        return <<<'HTML'
                 <div
                     x-cloak
                     x-data="{
@@ -62,5 +62,5 @@ class Popover extends Component
                   </div>
                 </div>
             HTML;
-  }
+    }
 }

--- a/src/View/Components/Popover.php
+++ b/src/View/Components/Popover.php
@@ -8,23 +8,24 @@ use Illuminate\View\Component;
 
 class Popover extends Component
 {
-    public string $uuid;
+  public string $uuid;
 
-    public function __construct(
-        public ?string $position = "bottom",
-        public ?string $offset = "10",
+  public function __construct(
+    public ?string $id = null,
+    public ?string $position = "bottom",
+    public ?string $offset = "10",
 
-        // Slots
-        public mixed $trigger = null,
-        public mixed $content = null
+    // Slots
+    public mixed $trigger = null,
+    public mixed $content = null
 
-    ) {
-        $this->uuid = "mary" . md5(serialize($this));
-    }
+  ) {
+    $this->uuid = "mary" . md5(serialize($this)) . $id;
+  }
 
-    public function render(): View|Closure|string
-    {
-        return <<<'HTML'
+  public function render(): View|Closure|string
+  {
+    return <<<'HTML'
                 <div
                     x-cloak
                     x-data="{
@@ -61,5 +62,5 @@ class Popover extends Component
                   </div>
                 </div>
             HTML;
-    }
+  }
 }

--- a/src/View/Components/Progress.php
+++ b/src/View/Components/Progress.php
@@ -11,12 +11,12 @@ class Progress extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?float $value = 0,
         public ?float $max = 100,
         public ?bool $indeterminate = false,
-
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/ProgressRadial.php
+++ b/src/View/Components/ProgressRadial.php
@@ -11,11 +11,11 @@ class ProgressRadial extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?int $value = 0,
         public ?string $unit = '%'
-
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -12,6 +12,7 @@ class Radio extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -27,7 +28,7 @@ class Radio extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Range.php
+++ b/src/View/Components/Range.php
@@ -11,6 +11,7 @@ class Range extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -23,7 +24,7 @@ class Range extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Rating.php
+++ b/src/View/Components/Rating.php
@@ -11,9 +11,10 @@ class Rating extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public int $total = 5
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -12,6 +12,7 @@ class Select extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -36,7 +37,7 @@ class Select extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/SelectGroup.php
+++ b/src/View/Components/SelectGroup.php
@@ -12,6 +12,7 @@ class SelectGroup extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
@@ -34,7 +35,7 @@ class SelectGroup extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Signature.php
+++ b/src/View/Components/Signature.php
@@ -11,6 +11,7 @@ class Signature extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $height = '250',
         public ?string $clearText = 'Clear',
         public ?string $hint = null,
@@ -24,7 +25,7 @@ class Signature extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -40,7 +41,7 @@ class Signature extends Component
     public function setup(): string
     {
         return json_encode(array_merge([
-
+            
         ], $this->config));
     }
 

--- a/src/View/Components/Spotlight.php
+++ b/src/View/Components/Spotlight.php
@@ -11,6 +11,7 @@ class Spotlight extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $shortcut = "meta.g",
         public ?string $searchText = "Search ...",
         public ?string $noResultsText = "Nothing found.",
@@ -19,7 +20,7 @@ class Spotlight extends Component
         // Slots
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
         $this->url = $this->url ?? route('mary.spotlight', absolute: false);
     }
 

--- a/src/View/Components/Stat.php
+++ b/src/View/Components/Stat.php
@@ -13,6 +13,7 @@ class Stat extends Component
     public string $tooltipPosition = 'lg:tooltip-top';
 
     public function __construct(
+        public ?string $id = null,
         public ?string $value = null,
         public ?string $icon = null,
         public ?string $color = '',
@@ -24,7 +25,7 @@ class Stat extends Component
         public ?string $tooltipBottom = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
         $this->tooltip = $this->tooltip ?? $this->tooltipLeft ?? $this->tooltipRight ?? $this->tooltipBottom;
         $this->tooltipPosition = $this->tooltipLeft ? 'lg:tooltip-left' : ($this->tooltipRight ? 'lg:tooltip-right' : ($this->tooltipBottom ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }

--- a/src/View/Components/Step.php
+++ b/src/View/Components/Step.php
@@ -12,6 +12,7 @@ class Step extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public int $step,
         public string $text,
         public ?string $icon = null,
@@ -19,7 +20,7 @@ class Step extends Component
         public ?string $dataContent = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function iconHTML(): ?string

--- a/src/View/Components/Steps.php
+++ b/src/View/Components/Steps.php
@@ -11,12 +11,13 @@ class Steps extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public bool $vertical = false,
         public ?string $stepsColor = 'step-neutral',
         public ?string $stepperClasses = null
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Tab.php
+++ b/src/View/Components/Tab.php
@@ -12,13 +12,14 @@ class Tab extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $name = null,
         public ?string $label = null,
         public ?string $icon = null,
         public bool $disabled = false,
         public bool $hidden = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function tabLabel(string $label): string

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -18,6 +18,7 @@ class Table extends Component
     public mixed $loop = null;
 
     public function __construct(
+        public ?string $id = null,
         public array $headers,
         public ArrayAccess|array $rows,
         public ?bool $striped = false,
@@ -62,7 +63,7 @@ class Table extends Component
         unset($this->headers);
 
         // Serialize
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
 
         // Put them back
         $this->rowDecoration = $rowDecoration;

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -11,13 +11,14 @@ class Tabs extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $selected = null,
         public string $labelClass = 'font-semibold',
         public string $activeClass = 'border-b-2 border-b-base-content/50',
         public string $labelDivClass = 'border-b-2 border-b-base-content/10 flex overflow-x-auto',
         public string $tabsClass = 'relative w-full',
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -11,6 +11,7 @@ class Tags extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -31,7 +32,7 @@ class Tags extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -11,6 +11,7 @@ class Textarea extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
@@ -22,7 +23,7 @@ class Textarea extends Component
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string

--- a/src/View/Components/ThemeToggle.php
+++ b/src/View/Components/ThemeToggle.php
@@ -11,6 +11,7 @@ class ThemeToggle extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public ?string $value = null,
         public ?string $light = "Light",
         public ?string $dark = "Dark",
@@ -21,7 +22,7 @@ class ThemeToggle extends Component
         public ?bool $withLabel = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/TimelineItem.php
+++ b/src/View/Components/TimelineItem.php
@@ -11,6 +11,7 @@ class TimelineItem extends Component
     public string $uuid;
 
     public function __construct(
+        public ?string $id = null,
         public string $title,
         public ?string $subtitle = null,
         public ?string $description = null,
@@ -20,7 +21,7 @@ class TimelineItem extends Component
         public ?bool $last = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this));
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string


### PR DESCRIPTION
Like discussed, this PR adds the following to all components that currently have an $uuid proerty:

```php
public function __construct(
    public ?string $id = null, // Added this line if missing.
    ...
) {
    $this->uuid = "mary" . md5(serialize($this)) . $id; // Appended $id here if missing.
    ...
}
```

Closes #834.