### PR TITLE
Breadcrumbs: introduce as new component

### DIFF
--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -11,6 +11,7 @@ use Mary\View\Components\Accordion;
 use Mary\View\Components\Alert;
 use Mary\View\Components\Avatar;
 use Mary\View\Components\Badge;
+use Mary\View\Components\Breadcrumbs;
 use Mary\View\Components\Button;
 use Mary\View\Components\Calendar;
 use Mary\View\Components\Card;
@@ -120,6 +121,7 @@ class MaryServiceProvider extends ServiceProvider
         Blade::component($prefix . 'alert', Alert::class);
         Blade::component($prefix . 'avatar', Avatar::class);
         Blade::component($prefix . 'badge', Badge::class);
+        Blade::component($prefix . 'breadcrumbs', Breadcrumbs::class);
         Blade::component($prefix . 'button', Button::class);
         Blade::component($prefix . 'calendar', Calendar::class);
         Blade::component($prefix . 'card', Card::class);

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -37,9 +37,12 @@ class Breadcrumbs extends Component
 
     public function tooltipPosition(array $element): string
     {
-        return array_key_exists('tooltip-left', $element) ? 'lg:tooltip-left' :
-            (array_key_exists('tooltip-right', $element) ? 'lg:tooltip-right' :
-                (array_key_exists('tooltip-bottom', $element) ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
+        return match (true) {
+            isset($element['tooltip-left']) => 'lg:tooltip-left',
+            isset($element['tooltip-right']) => 'lg:tooltip-right',
+            isset($element['tooltip-bottom']) => 'lg:tooltip-bottom',
+            default => 'lg:tooltip-top',
+        };
     }
 
     public function render(): View|Closure|string

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Mary\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Breadcrumbs extends Component
+{
+    public string $uuid;
+
+    /**
+     * @param array  $items  The steps that should be displayed. Each element supports the keys 'label', 'link', 'icon' and 'tooltip'.
+     * @param string  $seperator  Any supported icon name, 'o-slash' by default.
+     * @param ?string  $linkItemClass  The classes that should be applied to each item with a link.
+     * @param ?string  $textItemClass  The classes that should be applied to each item without a link.
+     * @param ?string  $iconClass  The classes that should be applied to each items icon.
+     * @param ?string  $seperatorClass  The classes that should be applied to each seperator.
+     */
+    public function __construct(
+        public ?string $id = null,
+        public array $items = [],
+        public string $seperator = 'o-slash',
+        public ?string $linkItemClass = "btn btn-ghost btn-sm",
+        public ?string $textItemClass = "btn btn-ghost btn-sm pointer-events-none",
+        public ?string $iconClass = "h-5 w-5",
+        public ?string $seperatorClass = "h-4 w-4",
+    ) {
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
+    }
+
+    public function render(): View|Closure|string
+    {
+        return <<<'BLADE'
+                <ul {{ $attributes->merge(['class' => 'flex items-center']) }} wire:key="{{ $uuid }}">
+                    @foreach($items as $element)
+                        
+                        {{-- Tooltip --}}
+                        @php
+                            $tooltip = $element['tooltip'] ?? $element['tooltip-left'] ?? $element['tooltip-right'] ?? $element['tooltip-bottom'] ?? $element['tooltip-top'] ?? null;
+                            $tooltipPosition = array_key_exists('tooltip-left', $element) ? 'lg:tooltip-left' : (array_key_exists('tooltip-right', $element) ? 'lg:tooltip-right' : (array_key_exists('tooltip-bottom', $element) ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
+                        @endphp
+                        <li @class(["!inline-flex lg:tooltip $tooltipPosition" => $tooltip]) 
+                            @if($tooltip)
+                                data-tip="{{ $tooltip }}"
+                            @endif
+                        >
+
+                            @if ($element['link'] ?? null)
+                                <a href="{{ $element['link'] }}" @class([$linkItemClass])>
+                            @else
+                                <span @class([$textItemClass])>
+                            @endif
+
+                                {{-- Icon --}}
+                                @if($element['icon'] ?? null)
+                                    <x-icon :name="$element['icon']" @class([$iconClass]) />
+                                @endif
+
+                                {{-- Text --}}
+                                <span>
+                                    {{ $element['label'] ?? null }}
+                                </span>
+                                
+                            @if ($element['link'] ?? null)
+                                </a>
+                            @else
+                                </span>
+                            @endif
+
+                        </li>
+                        
+                        {{-- Seperator --}}
+                        @if (!$loop->last)
+                            <x-icon name="{{ $seperator }}" @class([$seperatorClass]) />
+                        @endif
+
+                    @endforeach
+                </ul>
+            BLADE;
+    }
+}

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -55,7 +55,7 @@ class Breadcrumbs extends Component
 
                                 {{-- Icon --}}
                                 @if($element['icon'] ?? null)
-                                    <x-icon :name="$element['icon']" @class([$iconClass]) />
+                                    <x-mary-icon :name="$element['icon']" @class([$iconClass]) />
                                 @endif
 
                                 {{-- Text --}}
@@ -73,7 +73,7 @@ class Breadcrumbs extends Component
                         
                         {{-- Seperator --}}
                         @if (!$loop->last)
-                            <x-icon name="{{ $seperator }}" @class([$seperatorClass]) />
+                            <x-mary-icon name="{{ $seperator }}" @class([$seperatorClass]) />
                         @endif
 
                     @endforeach

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -11,23 +11,35 @@ class Breadcrumbs extends Component
     public string $uuid;
 
     /**
-     * @param array  $items  The steps that should be displayed. Each element supports the keys 'label', 'link', 'icon' and 'tooltip'.
-     * @param string  $seperator  Any supported icon name, 'o-slash' by default.
+     * @param  array  $items  The steps that should be displayed. Each element supports the keys 'label', 'link', 'icon' and 'tooltip'.
+     * @param  string  $separator  Any supported icon name, 'o-slash' by default.
      * @param ?string  $linkItemClass  The classes that should be applied to each item with a link.
      * @param ?string  $textItemClass  The classes that should be applied to each item without a link.
      * @param ?string  $iconClass  The classes that should be applied to each items icon.
-     * @param ?string  $seperatorClass  The classes that should be applied to each seperator.
+     * @param ?string  $separatorClass  The classes that should be applied to each separator.
      */
     public function __construct(
         public ?string $id = null,
         public array $items = [],
-        public string $seperator = 'o-slash',
-        public ?string $linkItemClass = "btn btn-ghost btn-sm",
-        public ?string $textItemClass = "btn btn-ghost btn-sm pointer-events-none",
-        public ?string $iconClass = "h-5 w-5",
-        public ?string $seperatorClass = "h-4 w-4",
+        public string $separator = 'o-chevron-right',
+        public ?string $linkItemClass = "hover:underline text-sm",
+        public ?string $textItemClass = "text-sm",
+        public ?string $iconClass = "h-4 w-4",
+        public ?string $separatorClass = "h-3 w-3 mx-1 text-base-content/40",
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
+    }
+
+    public function tooltip(array $element): ?string
+    {
+        return $element['tooltip'] ?? $element['tooltip-left'] ?? $element['tooltip-right'] ?? $element['tooltip-bottom'] ?? $element['tooltip-top'] ?? null;
+    }
+
+    public function tooltipPosition(array $element): string
+    {
+        return array_key_exists('tooltip-left', $element) ? 'lg:tooltip-left' :
+            (array_key_exists('tooltip-right', $element) ? 'lg:tooltip-right' :
+                (array_key_exists('tooltip-bottom', $element) ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }
 
     public function render(): View|Closure|string
@@ -35,15 +47,13 @@ class Breadcrumbs extends Component
         return <<<'BLADE'
                 <ul {{ $attributes->merge(['class' => 'flex items-center']) }} wire:key="{{ $uuid }}">
                     @foreach($items as $element)
-                        
+
                         {{-- Tooltip --}}
-                        @php
-                            $tooltip = $element['tooltip'] ?? $element['tooltip-left'] ?? $element['tooltip-right'] ?? $element['tooltip-bottom'] ?? $element['tooltip-top'] ?? null;
-                            $tooltipPosition = array_key_exists('tooltip-left', $element) ? 'lg:tooltip-left' : (array_key_exists('tooltip-right', $element) ? 'lg:tooltip-right' : (array_key_exists('tooltip-bottom', $element) ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
-                        @endphp
-                        <li @class(["!inline-flex lg:tooltip $tooltipPosition" => $tooltip]) 
-                            @if($tooltip)
-                                data-tip="{{ $tooltip }}"
+                        <li
+                            @class(["lg:tooltip {$tooltipPosition($element)}" => $tooltip($element), "hidden sm:block" => !$loop->first && !$loop->last])
+
+                            @if($tooltip($element))
+                                data-tip="{{ $tooltip($element) }}"
                             @endif
                         >
 
@@ -55,27 +65,34 @@ class Breadcrumbs extends Component
 
                                 {{-- Icon --}}
                                 @if($element['icon'] ?? null)
-                                    <x-mary-icon :name="$element['icon']" @class([$iconClass]) />
+                                    <x-mary-icon :name="$element['icon']" @class(["mb-0.5", $iconClass]) />
                                 @endif
 
                                 {{-- Text --}}
                                 <span>
                                     {{ $element['label'] ?? null }}
                                 </span>
-                                
+
                             @if ($element['link'] ?? null)
                                 </a>
                             @else
                                 </span>
                             @endif
-
                         </li>
-                        
-                        {{-- Seperator --}}
-                        @if (!$loop->last)
-                            <x-mary-icon name="{{ $seperator }}" @class([$seperatorClass]) />
+
+                        @if($loop->remaining == 1 && $loop->count > 2)
+                            <span class="sm:hidden">...</span>
                         @endif
 
+                        {{-- Separator --}}
+                        <span @class([
+                                "hidden",
+                                "!block" => ($loop->first || $loop->remaining == 1) && $loop->count > 1,
+                                "sm:!block" => !$loop->last && $loop->count > 1
+                             ])
+                        >
+                            <x-mary-icon :name="$separator" @class([$separatorClass]) />
+                        </span>
                     @endforeach
                 </ul>
             BLADE;


### PR DESCRIPTION
This PR introduces a new component for breadcrumbs 🚀

While the component follows the general HTML structure of daisy-ui, it offers a lot more flexibility and customization. In order to allow that the [breadcrumb classes](https://daisyui.com/components/breadcrumbs/) are not actually used.

A PR for the mary-ui.com page will follow shorty. Here are some examples:

![image](https://github.com/user-attachments/assets/013fce49-bf6e-455b-9d50-e434e8b57da7)

![image](https://github.com/user-attachments/assets/b8562921-5e2f-41d5-ade0-d11ed610b23a)

![image](https://github.com/user-attachments/assets/a58626dc-bd18-46f9-a028-77d8a1c712eb)

Closes #798 