### PR TITLE
All components: use daisyUI CSS variable for borders.

### DIFF
--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -73,7 +73,7 @@ class Card extends Component
                             </div>
 
                             @if($separator)
-                                <hr class="mt-3 border-base-content/10" />
+                                <hr class="mt-3 border-t-[length:var(--border)] border-base-content/10" />
 
                                 @if($progressIndicator)
                                     <div class="h-0.5 -mt-4 mb-4">
@@ -96,7 +96,7 @@ class Card extends Component
 
                     @if($actions)
                         @if($separator)
-                            <hr class="mt-5 border-base-content/10" />
+                            <hr class="mt-5 border-t-[length:var(--border)] border-base-content/10" />
                         @else
                             <div></div>
                         @endif

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -32,7 +32,7 @@ class Collapse extends Component
                 <div
                     {{
                         $attributes->class([
-                            'collapse border border-base-content/10',
+                            'collapse border-[length:var(--border)] border-base-content/10',
                             'join-item' => !$noJoin,
                             'collapse-arrow' => !$collapsePlusMinus && !$noIcon,
                             'collapse-plus' => $collapsePlusMinus && !$noIcon
@@ -60,7 +60,7 @@ class Collapse extends Component
                         </div>
                         <div {{ $content->attributes->merge(["class" => "collapse-content text-sm"]) }} wire:key="content-{{ $uuid }}">
                             @if($separator)
-                                <hr class="mb-3 border-base-content/10" />
+                                <hr class="mb-3 border-t-[length:var(--border)] border-base-content/10" />
                             @endif
 
                             {{ $content }}

--- a/src/View/Components/Diff.php
+++ b/src/View/Components/Diff.php
@@ -50,7 +50,7 @@ class Diff extends Component
                         }
                 }"
              >
-                <div x-ref="diff{{ $uuid }}" class="[&_.d2h-diff-table]:!text-xs [&_.d2h-file-header]:!bg-base-100 [&_.d2h-file-wrapper]:!border-dashed [&_.d2h-file-wrapper]:!border [&_.d2h-file-wrapper]:!bg-base-100 [&_.d2h-del]:!bg-red-50 [&_.d2h-ins]:!bg-green-50 [&_.d2h-code-line-ctn]:!whitespace-pre-wrap [&_.d2h-code-side-line]:!w-auto">
+                <div x-ref="diff{{ $uuid }}" class="[&_.d2h-diff-table]:!text-xs [&_.d2h-file-header]:!bg-base-100 [&_.d2h-file-wrapper]:!border-dashed [&_.d2h-file-wrapper]:!border-[length:var(--border)] [&_.d2h-file-wrapper]:!bg-base-100 [&_.d2h-del]:!bg-red-50 [&_.d2h-ins]:!bg-green-50 [&_.d2h-code-line-ctn]:!whitespace-pre-wrap [&_.d2h-code-side-line]:!w-auto">
                 </div>
             </div>
         HTML;

--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -52,7 +52,7 @@ class Dropdown extends Component
 
                 <ul
                     @class([
-                        'p-2','shadow','menu','z-[1]','border','border-base-content/10','bg-base-100', 'rounded-box','w-auto','min-w-max',
+                        'p-2','shadow','menu','z-[1]','border-[length:var(--border)]','border-base-content/10','bg-base-100', 'rounded-box','w-auto','min-w-max',
                         'dropdown-content' => $noXAnchor,
                     ])
                     @click="open = false"

--- a/src/View/Components/Form.php
+++ b/src/View/Components/Form.php
@@ -29,7 +29,7 @@ class Form extends Component
 
                     @if ($actions)
                         @if(!$noSeparator)
-                            <hr class="border-base-content/10 my-3" />
+                            <hr class="border-t-[length:var(--border)] border-base-content/10 my-3" />
                         @else
                             <div></div>
                         @endif

--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -74,12 +74,12 @@ class Header extends Component
                     </div>
 
                     @if($separator)
-                        <hr class="border-base-content/10 mt-3" />
+                        <hr class="border-t-[length:var(--border)] border-base-content/10 mt-3" />
 
                         @if($progressIndicator)
                             <div class="h-0.5 -mt-4 mb-4">
                                 <progress
-                                    class="progress progress-primary w-full h-0.5"
+                                    class="progress progress-primary w-full h-[var(--border)]"
                                     wire:loading
 
                                     @if($progressTarget())

--- a/src/View/Components/Hr.php
+++ b/src/View/Components/Hr.php
@@ -29,14 +29,14 @@ class Hr extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div class="h-[2px] border-t border-t-base-content/10 my-5">
+                <div class="h-[2px] border-t-[length:var(--border)] border-t-base-content/10 my-5">
                     <progress
                         class="progress progress-primary hidden h-[1px]"
-                        wire:loading.class="!h-[2px] !block"
+                        wire:loading.class="!h-[length:var(--border)] !block"
 
                         @if($progressTarget())
                             wire:target="{{ $progressTarget() }}"
-                         @endif></progress>
+                        @endif></progress>
                 </div>
             HTML;
     }

--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -153,10 +153,10 @@ class ImageLibrary extends Component
                         <div
                             x-data="{ sortable: null }"
                             x-init="sortable = new Sortable($el, { animation: 150, ghostClass: 'bg-base-300', filter: '.ignore-drag', onEnd: (ev) => refreshMediaOrder(sortable.toArray()) })"
-                            class="border border-base-content/10 border-dotted rounded-lg"
+                            class="border-[length:var(--border)] border-base-content/10 border-dotted rounded-lg"
                         >
                             @foreach($preview as $key => $image)
-                                <div class="relative border-b-base-content/10 border-b border-dotted last:border-none cursor-move hover:bg-base-200" data-id="{{ $image['uuid'] }}">
+                                <div class="relative border-b-base-content/10 border-b-[length:var(--border)] border-dotted last:border-none cursor-move hover:bg-base-200" data-id="{{ $image['uuid'] }}">
                                     <div wire:key="preview-{{ $image['uuid'] }}" class="py-2 ps-16 pe-10 tooltip" data-tip="{{ $changeText }}">
                                         {{-- IMAGE --}}
                                         <img

--- a/src/View/Components/ListItem.php
+++ b/src/View/Components/ListItem.php
@@ -104,7 +104,7 @@ class ListItem extends Component
                 </div>
 
                 @if(!$noSeparator)
-                    <hr class="border-base-content/10"/>
+                    <hr class="border-t-[length:var(--border)] border-base-content/10"/>
                 @endif
             </div>
         HTML;

--- a/src/View/Components/Menu.php
+++ b/src/View/Components/Menu.php
@@ -39,7 +39,7 @@ class Menu extends Component
                     @endif
 
                     @if($separator)
-                        <hr class="mb-3 border-base-content/10" />
+                        <hr class="mb-3 border-t-[length:var(--border)] border-base-content/10" />
                     @endif
 
                     {{ $slot }}

--- a/src/View/Components/MenuSeparator.php
+++ b/src/View/Components/MenuSeparator.php
@@ -21,7 +21,7 @@ class MenuSeparator extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <hr class="my-3 border-base-content/10"/>
+                <hr class="my-3 border-t-[length:var(--border)] border-base-content/10"/>
 
                 @if($title)
                     <li {{ $attributes->class(["menu-title text-inherit uppercase"]) }}>

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -64,7 +64,7 @@ class Modal extends Component
                         </div>
 
                         @if($separator && $actions)
-                            <hr class="border-base-content/10 mt-5" />
+                            <hr class="border-t-[length:var(--border)] border-base-content/10 mt-5" />
                         @endif
 
                         @if($actions)

--- a/src/View/Components/Nav.php
+++ b/src/View/Components/Nav.php
@@ -22,7 +22,7 @@ class Nav extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                    <div {{ $attributes->class(["bg-base-100 border-base-content/10 border-b", "sticky top-0 z-10" => $sticky]) }}>
+                    <div {{ $attributes->class(["bg-base-100 border-base-content/10 border-b-[length:var(--border)]", "sticky top-0 z-10" => $sticky]) }}>
                         <div @class(["flex items-center px-6 py-3",  "max-w-screen-2xl mx-auto" => !$fullWidth])>
                             <div {{ $brand?->attributes->class(["flex-1 flex items-center"]) }}>
                                 {{ $brand }}

--- a/src/View/Components/Pagination.php
+++ b/src/View/Components/Pagination.php
@@ -34,7 +34,7 @@ class Pagination extends Component
     {
         return <<<'HTML'
             <div class="mary-table-pagination">
-                <div {{ $attributes->class(["mb-4 border-t border-t-base-content/10"]) }}></div>
+                <div {{ $attributes->class(["mb-4 border-t-[length:var(--border)] border-t-base-content/10"]) }}></div>
                 <div class="justify-between md:flex md:flex-row w-auto md:w-full items-center overflow-y-auto pl-2 pr-2 relative">
                     @if($isShowable())
                     <div class="flex flex-row justify-center md:justify-start mb-2 md:mb-0 py-1">

--- a/src/View/Components/Pagination.php
+++ b/src/View/Components/Pagination.php
@@ -34,7 +34,7 @@ class Pagination extends Component
     {
         return <<<'HTML'
             <div class="mary-table-pagination">
-                <div {{ $attributes->class(["mb-4 border-t-[length:var(--border)] border-t-base-content/10"]) }}></div>
+                <div {{ $attributes->class(["mb-4 border-t-[length:var(--border)] border-t-base-content/5"]) }}></div>
                 <div class="justify-between md:flex md:flex-row w-auto md:w-full items-center overflow-y-auto pl-2 pr-2 relative">
                     @if($isShowable())
                     <div class="flex flex-row justify-center md:justify-start mb-2 md:mb-0 py-1">

--- a/src/View/Components/Popover.php
+++ b/src/View/Components/Popover.php
@@ -8,24 +8,24 @@ use Illuminate\View\Component;
 
 class Popover extends Component
 {
-  public string $uuid;
+    public string $uuid;
 
-  public function __construct(
-    public ?string $id = null,
-    public ?string $position = "bottom",
-    public ?string $offset = "10",
+    public function __construct(
+        public ?string $id = null,
+        public ?string $position = "bottom",
+        public ?string $offset = "10",
 
-    // Slots
-    public mixed $trigger = null,
-    public mixed $content = null
+        // Slots
+        public mixed $trigger = null,
+        public mixed $content = null
 
-  ) {
-    $this->uuid = "mary" . md5(serialize($this)) . $id;
-  }
+    ) {
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
+    }
 
-  public function render(): View|Closure|string
-  {
-    return <<<'HTML'
+    public function render(): View|Closure|string
+    {
+        return <<<'HTML'
                 <div
                     x-cloak
                     x-data="{
@@ -62,5 +62,5 @@ class Popover extends Component
                   </div>
                 </div>
             HTML;
-  }
+    }
 }

--- a/src/View/Components/Popover.php
+++ b/src/View/Components/Popover.php
@@ -8,24 +8,24 @@ use Illuminate\View\Component;
 
 class Popover extends Component
 {
-    public string $uuid;
+  public string $uuid;
 
-    public function __construct(
-        public ?string $id = null,
-        public ?string $position = "bottom",
-        public ?string $offset = "10",
+  public function __construct(
+    public ?string $id = null,
+    public ?string $position = "bottom",
+    public ?string $offset = "10",
 
-        // Slots
-        public mixed $trigger = null,
-        public mixed $content = null
+    // Slots
+    public mixed $trigger = null,
+    public mixed $content = null
 
-    ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
-    }
+  ) {
+    $this->uuid = "mary" . md5(serialize($this)) . $id;
+  }
 
-    public function render(): View|Closure|string
-    {
-        return <<<'HTML'
+  public function render(): View|Closure|string
+  {
+    return <<<'HTML'
                 <div
                     x-cloak
                     x-data="{
@@ -56,11 +56,11 @@ class Popover extends Component
                     x-anchor.{{ $position }}.offset.{{ $offset }}="$refs.myTrigger"
                     @mouseover="show()"
                     @mouseout="hide()"
-                    {{ $content->attributes->class(["z-[1] shadow-xl border border-base-content/10 w-fit p-3 rounded-md bg-base-100"]) }}
+                    {{ $content->attributes->class(["z-[1] shadow-xl border-[length:var(--border)] border-base-content/10 w-fit p-3 rounded-md bg-base-100"]) }}
                   >
                     {{ $content }}
                   </div>
                 </div>
             HTML;
-    }
+  }
 }

--- a/src/View/Components/Signature.php
+++ b/src/View/Components/Signature.php
@@ -40,9 +40,7 @@ class Signature extends Component
 
     public function setup(): string
     {
-        return json_encode(array_merge([
-            
-        ], $this->config));
+        return json_encode(array_merge([], $this->config));
     }
 
     public function render(): View|Closure|string
@@ -84,7 +82,7 @@ class Signature extends Component
                                 $attributes
                                     ->except("wire:model")
                                     ->class([
-                                        "border border-base-300 rounded-lg relative bg-white select-none touch-none block",
+                                        "border-[length:var(--border)] border-base-300 rounded-lg relative bg-white select-none touch-none block",
                                         "!border-error" => $errors->has($modelName())
                                     ])
                             }}

--- a/src/View/Components/Spotlight.php
+++ b/src/View/Components/Spotlight.php
@@ -163,7 +163,7 @@ class Spotlight extends Component
 
                             <!-- NO RESULTS -->
                             <template x-if="searchedWithNoResults && value != ''">
-                                <div class="text-base-content/50 p-3 border-t border-t-base-content/10 mary-spotlight-element">{{ $noResultsText }}</div>
+                                <div class="text-base-content/50 p-3 border-t-[length:var(--border)] border-t-base-content/10 mary-spotlight-element">{{ $noResultsText }}</div>
                             </template>
 
                             <!-- RESULTS  -->
@@ -171,7 +171,7 @@ class Spotlight extends Component
                                 <template x-for="(item, index) in results" :key="index">
                                     <!-- ITEM -->
                                     <a x-bind:href="item.link" class="mary-spotlight-element" wire:navigate tabindex="0">
-                                        <div class="p-3 hover:bg-base-200 border-t border-t-base-content/10" >
+                                        <div class="p-3 hover:bg-base-200 border-t-[length:var(--border)] border-t-base-content/10" >
                                             <div class="flex gap-3 items-center">
                                                 <!-- AVATAR -->
                                                 <template x-if="item.icon">

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -14,8 +14,8 @@ class Tabs extends Component
         public ?string $id = null,
         public ?string $selected = null,
         public string $labelClass = 'font-semibold',
-        public string $activeClass = 'border-b-2 border-b-base-content/50',
-        public string $labelDivClass = 'border-b-2 border-b-base-content/10 flex overflow-x-auto',
+        public string $activeClass = 'border-b-[length:var(--border)] border-b-base-content/50',
+        public string $labelDivClass = 'border-b-[length:var(--border)] border-b-base-content/10 flex overflow-x-auto',
         public string $tabsClass = 'relative w-full',
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
@@ -42,7 +42,7 @@ class Tabs extends Component
                                  }
                         }"
                         class="{{ $tabsClass }}"
-                        x-class="font-semibold border-b-2 border-b-base-content/50 border-b-base-content/10 flex overflow-x-auto scrollbar-hide relative w-full"
+                        x-class="font-semibold border-b-[length:var(--border)] border-b-base-content/50 border-b-base-content/10 flex overflow-x-auto scrollbar-hide relative w-full"
                     >
                         <!-- TAB LABELS -->
                         <div class="{{ $labelDivClass }}">


### PR DESCRIPTION
This is an example of how to adhere border sizes to daisy-ui themes. Here is a quick comparison:

## Current (old) behaviour:
Default theme 1px boder:
![image](https://github.com/user-attachments/assets/88ce36d5-3753-42ca-b606-7d4940ac485d)

Custom theme 5px border:
![image](https://github.com/user-attachments/assets/6bf21722-87f0-4d23-8aad-6cc877392ab5)

## New behaviour:
Default theme 1px boder:
![image](https://github.com/user-attachments/assets/a7adc32b-8e88-4842-8951-61424fe592ff)

Custom theme 5px border:
![image](https://github.com/user-attachments/assets/58ac513b-8c43-4278-aa7c-7bc86b8bfd33)

## Additional notes
The theme was changed by adding the following code to app.css
```css
@plugin "daisyui/theme" {
    name: light;
    --border: 5px;
}
```

I also noticed a slight difference in color in this example. The border uses `border-t-base-content/10` but the table rows use `border-t-base-content/5`, not sure if that is intentional.

Closes #851 