### PR TITLE
All menu components: add `icon-classes` 

### DIFF
--- a/src/View/Components/Menu.php
+++ b/src/View/Components/Menu.php
@@ -14,6 +14,7 @@ class Menu extends Component
         public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
+        public ?string $iconClasses = 'w-4 h-4',
         public ?bool $separator = false,
         public ?bool $activateByRoute = false,
         public ?string $activeBgColor = 'bg-base-300',
@@ -23,14 +24,14 @@ class Menu extends Component
 
     public function render(): View|Closure|string
     {
-        return <<<'HTML'
+        return <<<'BLADE'
                 <ul {{ $attributes->class(["menu w-full"]) }} >
                     @if($title)
                         <li class="menu-title text-inherit uppercase">
                             <div class="flex items-center gap-2">
 
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="w-4 h-4 inline-flex"  />
+                                    <x-mary-icon :name="$icon" @class(['inline-flex', $iconClasses])  />
                                 @endif
 
                                 {{ $title }}
@@ -44,6 +45,6 @@ class Menu extends Component
 
                     {{ $slot }}
                 </ul>
-            HTML;
+            BLADE;
     }
 }

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -15,6 +15,7 @@ class MenuItem extends Component
         public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
+        public ?string $iconClasses = null,
         public ?string $spinner = null,
         public ?string $link = null,
         public ?string $route = null,
@@ -101,7 +102,7 @@ class MenuItem extends Component
 
                         @if($icon)
                             <span class="block py-0.5" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
-                                <x-mary-icon :name="$icon" class="mb-0.5" />
+                                <x-mary-icon :name="$icon" @class(['mb-0.5', $iconClasses]) />
                             </span>
                         @endif
 

--- a/src/View/Components/MenuSeparator.php
+++ b/src/View/Components/MenuSeparator.php
@@ -14,13 +14,14 @@ class MenuSeparator extends Component
         public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
+        public ?string $iconClasses = null,
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
-        return <<<'HTML'
+        return <<<'BLADE'
                 <hr class="my-3 border-base-content/10"/>
 
                 @if($title)
@@ -28,13 +29,13 @@ class MenuSeparator extends Component
                         <div class="flex items-center gap-2">
 
                             @if($icon)
-                                <x-mary-icon :name="$icon"  />
+                                <x-mary-icon :name="$icon" @class([$iconClasses]) />
                             @endif
 
                             {{ $title }}
                         </div>
                     </li>
                 @endif
-            HTML;
+            BLADE;
     }
 }

--- a/src/View/Components/MenuSub.php
+++ b/src/View/Components/MenuSub.php
@@ -14,6 +14,7 @@ class MenuSub extends Component
         public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
+        public ?string $iconClasses = null,
         public bool $open = false,
         public ?bool $enabled = true,
     ) {
@@ -26,7 +27,7 @@ class MenuSub extends Component
             return '';
         }
 
-        return <<<'HTML'
+        return <<<'BLADE'
                 @aware(['activeBgColor' => 'bg-base-300'])
 
                 @php
@@ -52,7 +53,7 @@ class MenuSub extends Component
                     <details :open="show" @if($submenuActive) open @endif @click.stop>
                         <summary @click.prevent="toggle()" @class(["hover:text-inherit px-4 py-1.5 my-0.5 text-inherit", $activeBgColor => $submenuActive])>
                             @if($icon)
-                                <x-mary-icon :name="$icon" class="inline-flex my-0.5"  />
+                                <x-mary-icon :name="$icon" @class(['inline-flex my-0.5', $iconClasses]) />
                             @endif
 
                             <span class="mary-hideable whitespace-nowrap truncate">{{ $title }}</span>
@@ -63,6 +64,6 @@ class MenuSub extends Component
                         </ul>
                     </details>
                 </li>
-            HTML;
+                BLADE;
     }
 }

--- a/src/View/Components/MenuTitle.php
+++ b/src/View/Components/MenuTitle.php
@@ -14,23 +14,24 @@ class MenuTitle extends Component
         public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
+        public ?string $iconClasses = null,
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
-        return <<<'HTML'
+        return <<<'BLADE'
                 <li {{ $attributes->class(["menu-title"]) }}>
                     <div class="flex items-center gap-2">
 
                         @if($icon)
-                            <x-mary-icon :name="$icon"  />
+                            <x-mary-icon :name="$icon" @class([$iconClasses]) />
                         @endif
 
                         {{ $title }}
                     </div>
                 </li>
-            HTML;
+            BLADE;
     }
 }


### PR DESCRIPTION
This will add support for custom `ìcon-classes` to the following components:

- Menu
- MenuItem
- MenuSeparator
- MenuSub
- MenuTitle

Also the string in the `render()` method has been changed to BLADE instead of HTML for consistency and better syntax highlighting.

Closes #713 