### PR TITLE
Editor: fix TinyMCE undo/redo actions and dark mode setting

### DIFF
--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -112,6 +112,8 @@ class Editor extends Component
                                     setup: function(editor) {
                                         editor.on('keyup', (e) => value = editor.getContent())
                                         editor.on('change', (e) => value = editor.getContent())
+                                        editor.on('undo', (e) => value = editor.getContent())
+                                        editor.on('redo', (e) => value = editor.getContent())
                                         editor.on('init', () =>  editor.setContent(value ?? ''))
                                         editor.on('OpenWindow', (e) => tinymce.activeEditor.topLevelWindow = e.dialog)
 

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -100,8 +100,8 @@ class Editor extends Component
                                     target: $refs.tinymce,
                                     images_upload_url: uploadUrl,
                                     readonly: {{ json_encode($attributes->get('readonly') || $attributes->get('disabled')) }},
-                                    skin: document.documentElement.getAttribute('data-theme') != 'dark' ? 'oxide' : 'oxide-dark',
-                                    content_css: document.documentElement.getAttribute('data-theme')!= 'dark' ? 'default' : 'dark',
+                                    skin: document.documentElement.getAttribute('class') == 'dark' ? 'oxide-dark' : 'oxide',
+                                    content_css: document.documentElement.getAttribute('class') == 'dark' ? 'dark' : 'default',
 
                                     @if($attributes->get('disabled'))
                                         content_style: 'body { opacity: 50% }',


### PR DESCRIPTION
1. Undo/redo actions are not committing to the editor content and require separate event listeners in the editor setup to recognise these actions.
2. The editor receives a dark variant from the 'data-theme' attribute. This works fine if you only use the 'dark' theme name to toggle dark mode, however, it won't work if you use another dark theme name. The solution is to change TinyMCE's 'skin' and 'content_css' settings to accept the 'dark' variant from the 'class' instead of the 'data-theme' attribute.