### PR TITLE
Add icon and icon classes support for Header

### DIFF
--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -19,6 +19,10 @@ class Header extends Component
         public ?bool $withAnchor = false,
         public ?string $size = 'text-2xl',
 
+        // Icon
+        public ?string $icon = null,
+        public ?string $iconClasses = null,
+
         // Slots
         public mixed $middle = null,
         public mixed $actions = null,
@@ -41,12 +45,16 @@ class Header extends Component
                 <div id="{{ $anchor }}" {{ $attributes->class(["mb-10", "mary-header-anchor" => $withAnchor]) }}>
                     <div class="flex flex-wrap gap-5 justify-between items-center">
                         <div>
-                            <div @class(["$size font-extrabold", is_string($title) ? '' : $title?->attributes->get('class') ]) >
+                            <div @class(["flex", "items-center", "$size font-extrabold", is_string($title) ? '' : $title?->attributes->get('class') ]) >
                                 @if($withAnchor)
                                     <a href="#{{ $anchor }}">
                                 @endif
+                                
+                                @if($icon)
+                                    <x-icon name="{{ $icon }}" class="{{ $iconClasses }}" />
+                                @endif
 
-                                {{ $title }}
+                                <span @class(["ml-2" => $icon])>{{ $title }}</span>
 
                                 @if($withAnchor)
                                     </a>


### PR DESCRIPTION
Added the `icon` property to let the user pick an icon for the header, along with an `icon-classes` property to let the user have control of the size, margin, colors, ... of the icon.

Added some flex classes to the title parent `<div>` to align the title and the icon automatically, and wrapped the title content in a `<span>` to add a small margin when there's an icon.

Showcase of the result :

![image](https://github.com/user-attachments/assets/89dd14a5-8e9a-4af8-8a41-c6ef671e4991)

![image](https://github.com/user-attachments/assets/3bb90fd9-e99f-4710-b0c0-df52e863510d)

```html
<x-header icon="o-gif" icon-classes="w-8 h-8 text-red-500" title="Hello" subtitle="messing around with the icon" separator progress-indicator>
        <x-slot:middle class="!justify-end">
            <x-input placeholder="Search..." wire:model.live.debounce="search" clearable icon="o-magnifying-glass" />
        </x-slot:middle>
        <x-slot:actions>
            <x-button label="Filters" @click="$wire.drawer = true" responsive icon="o-funnel" class="btn-primary" />
        </x-slot:actions>
    </x-header>
```
