### PR TITLE
MenuItem: Add disabled property and rename enabled as hidden

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -25,7 +25,8 @@ class MenuItem extends Component
         public ?string $badgeClasses = null,
         public ?bool $active = false,
         public ?bool $separator = false,
-        public ?bool $enabled = true,
+        public ?bool $hidden = false,
+        public ?bool $disabled = false,
         public ?bool $exact = false
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
@@ -62,14 +63,14 @@ class MenuItem extends Component
 
     public function render(): View|Closure|string
     {
-        if ($this->enabled === false) {
+        if ($this->hidden === true) {
             return '';
         }
 
         return <<<'BLADE'
                 @aware(['activateByRoute' => false, 'activeBgColor' => 'bg-base-300'])
 
-                <li>
+                <li @class(['menu-disabled' => $disabled])>
                     <a
                         {{
                             $attributes->class([


### PR DESCRIPTION
This PR renames the `$enabled` property as `$hidden` for better readability, and adds the `$disabled` property to allow a menu item to be disabled based on the [daisyUI menu disabled class](https://daisyui.com/components/menu/#menu-with-disabled-items).

Showcase of the result :

![image](https://github.com/user-attachments/assets/ceb7f512-715e-4028-8c8a-09a443420c21)

![image](https://github.com/user-attachments/assets/b740816b-30f7-4f0f-843b-f09a8cb681fd)

Code sample :

```blade
<x-menu activate-by-route>
    <x-menu-item title="Hello" icon="o-sparkles" link="/" />

    <x-menu-sub title="Settings" icon="o-cog-6-tooth">
        <x-menu-item :disabled=true title="Wifi" icon="o-wifi" link="####" />
        <x-menu-item :hidden=true title="Archives" icon="o-archive-box" link="####" />
    </x-menu-sub>
</x-menu>
```