### PR TITLE
File: Set it `w-full`

### DIFF
--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -167,7 +167,7 @@ class File extends Component
 
                             {{
                                 $attributes->whereDoesntStartWith('class')->class([
-                                    "file-input",
+                                    "file-input w-full",
                                     "!file-input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError,
                                     "hidden" => $slot->isNotEmpty()
                                 ])


### PR DESCRIPTION
Set `w-full` as the default to ensure consistent styling across all input components.

Fix #876 