### PR TITLE
Card: Layout improvements

### DIFF
--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -53,7 +53,7 @@ class Card extends Component
 
                     @if($title || $subtitle)
                         <div class="pb-5">
-                            <div class="flex justify-between items-center w-full">
+                            <div class="flex gap-3 justify-between items-center w-full">
                                 <div class="grow-1">
                                     @if($title)
                                         <div @class(["text-xl font-bold", is_string($title) ? '' : $title?->attributes->get('class') ]) >

--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -53,8 +53,8 @@ class Card extends Component
 
                     @if($title || $subtitle)
                         <div class="pb-5">
-                            <div class="flex justify-between items-center">
-                                <div>
+                            <div class="flex justify-between items-center w-full">
+                                <div class="grow-1">
                                     @if($title)
                                         <div @class(["text-xl font-bold", is_string($title) ? '' : $title?->attributes->get('class') ]) >
                                             {{ $title }}
@@ -90,7 +90,7 @@ class Card extends Component
                         </div>
                     @endif
 
-                    <div>
+                    <div class="grow-1">
                         {{ $slot }}
                     </div>
 
@@ -101,7 +101,7 @@ class Card extends Component
                             <div></div>
                         @endif
 
-                        <div class="flex justify-end gap-3 pt-5">
+                        <div @class(["flex w-full items-end justify-end gap-3 pt-5", is_string($actions) ? '' : $actions?->attributes->get('class') ])>
                             {{ $actions }}
                         </div>
                     @endif


### PR DESCRIPTION
Improvements in this commit are:
 1. From the original question in issue #848: The title and subtitle will try to fill the full width of the card.<br/>This allows the title and subtitle to be divided into 2 parts (e.g. the title text and an icon), clearly separted from one another by e.g. applying `justify-between` to it.<br/>FYI: I have introduced a `gap-3` (same as the gap applied to the actions slot) between the title/subtitle and the menu. The card looks off without it.
 2. From my additional question in issue #848: The actions will also fill the full width of the card. Moreover, the actions slot can now be specified CS `class`es.<br/>This allows to lay them out in distrinct groups too.<br/>Note that unlike the title/subtitle, actions are applied `justify-end`. As a result, `justify-between` alone will not work; `!justify-between` must be used instead to override it. You should probably include that in your documentation. Alternatively, you could remove the default `justify-end` so that control of the button placement is easier to users, but I am not going to make that call myself. 
 3. The default slot is now applied `grow-1`.<br/>This pushes the actions and the separator between them as far down as possible, when, like in the below screenshot, cards are layed out in a CSS grid and do not have the same intrinsic height.<br/>On that topic, I added `items-end` to the actions slot, so that even if it is made of several `div`s, each of a different height, buttons will preferentially be aligned to the bottom of the padding area.<br/>Note that the  buttons in the 2 _Your stats_  cards are in the default slot, **not** in the actions slot, explaining why the `Save` buttons stay up there. 

Below is a of the improvements.
 - First are the 4 cards showcased on https://mary-ui.com/docs/components/card, hopefully showing this does not break anything down.
 - The last 2 cards in the grid show the 3 above improvements.


```
<x-card separator>
    Full width title + full width actions (using spacer div)
    <x-slot:figure>
        <img src="https://picsum.photos/500/200" />
    </x-slot:figure>
    <x-slot:title class="flex flex-row justify-between w-full">
        <div>ABC</div>
        <div>DEF</div>
    </x-slot:title>
    <x-slot:subtitle class="flex flex-row justify-between w-full">
        <div>GHI</div>
        <div>JKL</div>
    </x-slot:subtitle>
    <x-slot:actions separator class="flex !justify-between">
        <x-button label="Action 1" class="btn-secondary" />
        <x-button label="Action 2" class="btn-secondary" />
        <div class="grow-1"></div>
        <x-button label="Ok" class="btn-primary" />
    </x-slot:actions>
</x-card>

<x-card separator>
    Full width title (minus menu) + full width actions (using child div) 
    <x-slot:figure>
        <img src="https://picsum.photos/500/200" />
    </x-slot:figure>
    <x-slot:title class="flex flex-row !justify-between w-full">
        <div>ABC</div>
        <div>DEF</div>
    </x-slot:title>
    <x-slot:subtitle class="flex flex-row !justify-between w-full">
        <div>GHI</div>
        <div>JKL</div>
    </x-slot:subtitle>
    <x-slot:menu>
        <x-button icon="o-share" class="btn-circle btn-sm" />
        <x-icon name="o-heart" class="cursor-pointer" />
    </x-slot:menu>
    <x-slot:actions separator class="flex !justify-between">
        <div class="flex gap-3">
        <x-button label="Action 1" class="btn-secondary" />
        <x-button label="Action 2" class="btn-secondary" />
        </div>
        <x-button label="Ok" class="btn-primary" />
    </x-slot:actions>
</x-card>
```

![image](https://github.com/user-attachments/assets/50e738c3-f48d-4c53-8acb-7f00b4c97f50)
