### PR TITLE
Header: use the internal "x-mary-icon" component

### DIFF
--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -51,7 +51,7 @@ class Header extends Component
                                 @endif
                                 
                                 @if($icon)
-                                    <x-icon name="{{ $icon }}" class="{{ $iconClasses }}" />
+                                    <x-mary-icon name="{{ $icon }}" class="{{ $iconClasses }}" />
                                 @endif
 
                                 <span @class(["ml-2" => $icon])>{{ $title }}</span>


### PR DESCRIPTION
#### 🐛  The problem  
When a project changes Mary’s default component prefix (e.g. from `<x-*>` to `<x-mary-*>`), the `<x-mary-header>` component still tried to render its leading icon with:

```blade
<x-icon name="{{ $icon }}" … />
```
Because the tag itself wasn’t prefixed, Livewire/Laravel couldn’t resolve the component class and the icon simply disappeared (see issue #896).

#### ✅  What this PR does
File	Change
```
src/View/Components/Header.php	Replace <x-icon …> with <x-mary-icon …>
```
Only a single line is touched; behaviour is otherwise unchanged.