### PR TITLE
Modal/Drawer: dispatch `close` event

### DIFF
--- a/src/View/Components/Drawer.php
+++ b/src/View/Components/Drawer.php
@@ -20,7 +20,6 @@ class Drawer extends Component
         public ?bool $withCloseButton = false,
         public ?bool $closeOnEscape = false,
         public ?bool $withoutTrapFocus = false,
-        public ?string $onClose = null,
 
         //Slots
         public ?string $actions = null
@@ -56,6 +55,8 @@ class Drawer extends Component
                         }
                     }"
 
+                    x-init="$watch('open', value => { if (!value) $dispatch('close') })"
+
                     @if($closeOnEscape)
                         @keydown.window.escape="close()"
                     @endif
@@ -64,11 +65,9 @@ class Drawer extends Component
                         x-trap="open" x-bind:inert="!open"
                     @endif
 
-                    @if($onClose)
-                        x-effect="if(!open){ $wire.{{ $onClose }} }"
-                    @endif
-
                     @class(["drawer absolute z-50", "drawer-end" => $right])
+
+                    {{ $attributes->whereStartsWith('@') }}
                 >
                     <!-- Toggle visibility  -->
                     <input

--- a/src/View/Components/Drawer.php
+++ b/src/View/Components/Drawer.php
@@ -20,6 +20,7 @@ class Drawer extends Component
         public ?bool $withCloseButton = false,
         public ?bool $closeOnEscape = false,
         public ?bool $withoutTrapFocus = false,
+        public ?string $onClose = null,
 
         //Slots
         public ?string $actions = null
@@ -61,6 +62,10 @@ class Drawer extends Component
 
                     @if(!$withoutTrapFocus)
                         x-trap="open" x-bind:inert="!open"
+                    @endif
+
+                    @if($onClose)
+                        x-effect="if(!open){ $wire.{{ $onClose }} }"
                     @endif
 
                     @class(["drawer absolute z-50", "drawer-end" => $right])

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -112,6 +112,8 @@ class Editor extends Component
                                     setup: function(editor) {
                                         editor.on('keyup', (e) => value = editor.getContent())
                                         editor.on('change', (e) => value = editor.getContent())
+                                        editor.on('undo', (e) => value = editor.getContent())
+                                        editor.on('redo', (e) => value = editor.getContent())
                                         editor.on('init', () =>  editor.setContent(value ?? ''))
                                         editor.on('OpenWindow', (e) => tinymce.activeEditor.topLevelWindow = e.dialog)
 

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -100,8 +100,8 @@ class Editor extends Component
                                     target: $refs.tinymce,
                                     images_upload_url: uploadUrl,
                                     readonly: {{ json_encode($attributes->get('readonly') || $attributes->get('disabled')) }},
-                                    skin: document.documentElement.getAttribute('data-theme') != 'dark' ? 'oxide' : 'oxide-dark',
-                                    content_css: document.documentElement.getAttribute('data-theme')!= 'dark' ? 'default' : 'dark',
+                                    skin: document.documentElement.getAttribute('class') == 'dark' ? 'oxide-dark' : 'oxide',
+                                    content_css: document.documentElement.getAttribute('class') == 'dark' ? 'dark' : 'default',
 
                                     @if($attributes->get('disabled'))
                                         content_style: 'body { opacity: 50% }',

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -16,7 +16,6 @@ class Modal extends Component
         public ?bool $separator = false,
         public ?bool $persistent = false,
         public ?bool $withoutTrapFocus = false,
-        public ?string $onClose = null,
 
         // Slots
         public ?string $actions = null
@@ -34,6 +33,7 @@ class Modal extends Component
                         id="{{ $id }}"
                     @else
                         x-data="{open: @entangle($attributes->wire('model')).live }"
+                        x-init="$watch('open', value => { if (!value) $dispatch('close') })"
                         :class="{'modal-open !animate-none': open}"
                         :open="open"
                         @if(!$persistent)
@@ -43,10 +43,6 @@ class Modal extends Component
 
                     @if(!$withoutTrapFocus)
                         x-trap="open" x-bind:inert="!open"
-                    @endif
-
-                    @if($onClose)
-                        x-effect="if(!open){ $wire.{{ $onClose }} }"
                     @endif
                 >
                     <div class="modal-box {{ $boxClass }}">

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -16,6 +16,7 @@ class Modal extends Component
         public ?bool $separator = false,
         public ?bool $persistent = false,
         public ?bool $withoutTrapFocus = false,
+        public ?string $onClose = null,
 
         // Slots
         public ?string $actions = null
@@ -42,6 +43,10 @@ class Modal extends Component
 
                     @if(!$withoutTrapFocus)
                         x-trap="open" x-bind:inert="!open"
+                    @endif
+
+                    @if($onClose)
+                        x-effect="if(!open){ $wire.{{ $onClose }} }"
                     @endif
                 >
                     <div class="modal-box {{ $boxClass }}">


### PR DESCRIPTION
Add 'on-close' event to Modal and Drawer components to enable triggering of custom methods after component has closed. This is also useful to solve Livewire's current rehydration issue after a model has been deleted (refer [issue 900](https://github.com/robsontenorio/mary/issues/900)). 

Example Use:
```blade
<x-modal wire:model="showModal" on-close="someMethod()">
    Content...
</x-modal>
```