### PR TITLE
Table: change header sort icons and add neutral sort state

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -314,8 +314,8 @@ class Table extends Component
                                     >
                                         {{ isset(${"header_".$temp_key}) ? ${"header_".$temp_key}($header) : $header['label'] }}
 
-                                        @if($isSortable($header) && $isSortedBy($header))
-                                            <x-mary-icon :name="$getSort($header)['direction'] == 'asc' ? 'o-arrow-small-down' : 'o-arrow-small-up'"  class="w-4 h-4 mb-1" />
+                                        @if($isSortable($header))
+                                            <x-mary-icon :name="$isSortedBy($header) ? $getSort($header)['direction'] == 'asc' ? 'o-chevron-down' : 'o-chevron-up' : 'o-chevron-up-down'"  class="size-3! mb-1 ms-1" />
                                         @endif
                                     </th>
                                 @endforeach


### PR DESCRIPTION
1. Replace existing `o-arrow-small-down` and `o-arrow-small-up` table sort icons with `o-chevron-down` and `o-chevron-up`.
2. Add neutral state for distinguishing which headers are sortable and which are not.