### PR TITLE
Choices/ChoicesOffline: handle dynamic `disabled` and `readonly` states

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -55,7 +55,7 @@ class Choices extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . now()->timestamp;
+        $this->uuid = "mary" . md5(serialize($this)) . $id;
 
         if (($this->allowAll || $this->compact) && ($this->single || $this->searchable)) {
             throw new Exception("`allow-all` and `compact` does not work combined with `single` or `searchable`.");
@@ -101,7 +101,7 @@ class Choices extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div x-data="{ focused: false, selection: @entangle($attributes->wire('model')) }" wire:key="{{ $uuid }}">
+                <div x-data="{ focused: false, selection: @entangle($attributes->wire('model')) }">
                     <div
                         @click.outside = "clear()"
                         @keyup.esc = "clear()"
@@ -251,11 +251,12 @@ class Choices extends Component
 
                                     {{-- THE LABEL THAT HOLDS THE INPUT --}}
                                     <label
-                                        @click="focus()"
                                         x-ref="container"
 
                                         @if($isDisabled())
                                             disabled
+                                        @else
+                                            @click="focus()"
                                         @endif
 
                                         {{
@@ -295,7 +296,9 @@ class Choices extends Component
                                                                 <span x-text="option?.{{ $optionLabel }}"></span>
                                                             @endif
 
-                                                            <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="w-4 h-4 hover:text-error" />
+                                                            @if(!$isDisabled() && !$isReadonly())
+                                                                <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="w-4 h-4 hover:text-error" />
+                                                            @endif
                                                         </span>
                                                     </template>
                                                 @endif
@@ -314,10 +317,13 @@ class Choices extends Component
                                                 @keydown.arrow-down.prevent="focus()"
                                                 :required="isRequired && isSelectionEmpty"
                                                 :readonly="isReadonly || isDisabled || ! isSearchable"
-                                                :disabled="isDisabled"
                                                 class="w-1 !inline-block outline-hidden"
 
                                                 {{ $attributes->whereStartsWith('@') }}
+
+                                                @if($isDisabled())
+                                                    disabled
+                                                 @endif
 
                                                 @if($searchable)
                                                     @keydown.debounce.{{ $debounce }}="search($el.value, $event)"

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -255,7 +255,9 @@ class Choices extends Component
 
                                         @if($isDisabled())
                                             disabled
-                                        @else
+                                        @endif
+
+                                        @if(!$isDisabled() && !$isReadonly())
                                             @click="focus()"
                                         @endif
 
@@ -313,13 +315,17 @@ class Choices extends Component
                                             <input
                                                 x-ref="searchInput"
                                                 @input="focus(); resize();"
-                                                @focus="focus()"
                                                 @keydown.arrow-down.prevent="focus()"
                                                 :required="isRequired && isSelectionEmpty"
-                                                :readonly="isReadonly || isDisabled || ! isSearchable"
                                                 class="w-1 !inline-block outline-hidden"
 
                                                 {{ $attributes->whereStartsWith('@') }}
+
+                                                @if($isReadonly() || $isDisabled() || ! $searchable)
+                                                    readonly
+                                                @else
+                                                    @focus="focus()"
+                                                @endif
 
                                                 @if($isDisabled())
                                                     disabled

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -55,7 +55,7 @@ class Choices extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = "mary" . md5(serialize($this)) . now()->timestamp;
 
         if (($this->allowAll || $this->compact) && ($this->single || $this->searchable)) {
             throw new Exception("`allow-all` and `compact` does not work combined with `single` or `searchable`.");
@@ -101,7 +101,7 @@ class Choices extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div x-data="{ focused: false, selection: @entangle($attributes->wire('model')) }">
+                <div x-data="{ focused: false, selection: @entangle($attributes->wire('model')) }" wire:key="{{ $uuid }}">
                     <div
                         @click.outside = "clear()"
                         @keyup.esc = "clear()"
@@ -314,6 +314,7 @@ class Choices extends Component
                                                 @keydown.arrow-down.prevent="focus()"
                                                 :required="isRequired && isSelectionEmpty"
                                                 :readonly="isReadonly || isDisabled || ! isSearchable"
+                                                :disabled="isDisabled"
                                                 class="w-1 !inline-block outline-hidden"
 
                                                 {{ $attributes->whereStartsWith('@') }}

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -262,7 +262,9 @@ class ChoicesOffline extends Component
 
                                         @if($isDisabled())
                                             disabled
-                                        @else
+                                        @endif
+
+                                        @if(!$isDisabled() && !$isReadonly())
                                             @click="focus()"
                                         @endif
 
@@ -323,13 +325,21 @@ class ChoicesOffline extends Component
                                                 x-model="search"
                                                 @keyup="lookup()"
                                                 @input="focus(); resize();"
-                                                @focus="focus()"
                                                 @keydown.arrow-down.prevent="focus()"
                                                 :required="isRequired && isSelectionEmpty"
-                                                :readonly="isReadonly || isDisabled || ! isSearchable"
                                                 class="w-1 !inline-block outline-hidden"
 
                                                 {{ $attributes->whereStartsWith('@') }}
+
+                                                @if($isReadonly() || $isDisabled() || ! $searchable)
+                                                    readonly
+                                                @else
+                                                    @focus="focus()"
+                                                @endif
+
+                                                @if($isDisabled())
+                                                    disabled
+                                                 @endif
                                              />
                                         </div>
 

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -258,11 +258,12 @@ class ChoicesOffline extends Component
 
                                     {{-- THE LABEL THAT HOLDS THE INPUT --}}
                                     <label
-                                        @click="focus()"
                                         x-ref="container"
 
                                         @if($isDisabled())
                                             disabled
+                                        @else
+                                            @click="focus()"
                                         @endif
 
                                         {{
@@ -302,7 +303,9 @@ class ChoicesOffline extends Component
                                                                 <span x-text="option?.{{ $optionLabel }}"></span>
                                                             @endif
 
-                                                            <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="w-4 h-4 hover:text-error" />
+                                                            @if(!$isDisabled() && !$isReadonly())
+                                                                <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="w-4 h-4 hover:text-error" />
+                                                            @endif
                                                         </span>
                                                     </template>
                                                 @endif


### PR DESCRIPTION
Fix #899 

Disabled `<x-choices>` component is no longer clickable & focusable and it can be reactive based on the value provided by the parent livewire component.
