### PR TITLE
Input: handle `.blur` for money

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -152,7 +152,7 @@ class Input extends Component
                                         {{
                                             $attributes
                                                 ->merge(['type' => 'text'])
-                                                ->except($money ? ['wire:model', 'wire:model.live'] : '')
+                                                ->except($money ? ['wire:model', 'wire:model.live', 'wire:model.blur'] : '')
                                         }}
                                     />
 

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -146,6 +146,7 @@ class Input extends Component
                                             x-ref="myInput"
                                             :value="amount"
                                             x-on:input="$nextTick(() => $wire.set('{{ $modelName() }}', Currency.getUnmasked(), {{ json_encode($attributes->wire('model')->hasModifier('live')) }}))"
+                                            x-on:blur="$nextTick(() => $wire.set('{{ $modelName() }}', Currency.getUnmasked(), {{ json_encode($attributes->wire('model')->hasModifier('blur')) }}))"
                                             inputmode="numeric"
                                         @endif
 


### PR DESCRIPTION
When using the input component with money and locale attributes, it loses the formatting if you use `wire:model.blur`.

```php
 <x-input wire:model.blur="money" money locale="pt-BR"/>
```
![image](https://github.com/user-attachments/assets/c91fb18f-8649-45f9-8092-f8c4117caf98)

This PR fixes the problem.