### PR TITLE
Error messages on Pin

### DIFF
--- a/src/View/Components/Pin.php
+++ b/src/View/Components/Pin.php
@@ -16,6 +16,12 @@ class Pin extends Component
         public ?bool $numeric = false,
         public ?bool $hide = false,
         public ?string $hideType = "disc",
+        
+        // Validations
+        public ?string $errorField = null,
+        public ?string $errorClass = 'text-error',
+        public ?bool $omitError = false,
+        public ?bool $firstErrorOnly = false,
 
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
@@ -24,6 +30,11 @@ class Pin extends Component
     public function modelName(): ?string
     {
         return $this->attributes->whereStartsWith('wire:model')->first();
+    }
+    
+    public function errorFieldName(): ?string
+    {
+        return $this->errorField ?? $this->modelName();
     }
 
     public function render(): View|Closure|string
@@ -97,11 +108,25 @@ class Pin extends Component
                                         inputmode="numeric"
                                         x-mask="9"
                                     @endif
-
-                                    {{ $attributes->whereDoesntStartWith('wire')->class(['input input-border !w-12 font-black text-xl text-center']) }}
+                                    {{ 
+                                        $attributes->whereDoesntStartWith('wire')->class([
+                                            "input input-border !w-12 font-black text-xl text-center",
+                                            "!input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
+                                        ])
+                                    }}
                                 />
                             @endforeach
                         </div>
+                        {{-- ERROR --}}
+                        @if(!$omitError && $errors->has($errorFieldName()))
+                            @foreach($errors->get($errorFieldName()) as $message)
+                                @foreach(Arr::wrap($message) as $line)
+                                    <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                    @break($firstErrorOnly)
+                                @endforeach
+                                @break($firstErrorOnly)
+                            @endforeach
+                        @endif
                     </div>
                 </div>
             HTML;


### PR DESCRIPTION
The `Pin` field currently does not support error messages from the [form validation of Livewire](https://livewire.laravel.com/docs/forms#adding-validation).

This PR adds it to MaryUI.

Here is an example, hopefully with the exact same look and feel as `Input` fields:
 - Initial state, with no error:
    ![image](https://github.com/user-attachments/assets/a7838524-0ef8-437b-8b5a-17e6dd90f3db)
 - With an error:
    ![image](https://github.com/user-attachments/assets/a57140db-54b9-4e94-af61-7a5a33500dcd)

