### PR TITLE
ImageLibrary: add @touchend support for iOS 

### DIFF
--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -183,8 +183,8 @@ class ImageLibrary extends Component
 
                                     {{-- ACTIONS --}}
                                     <div class="absolute flex flex-col gap-2 top-3 start-3 cursor-pointer  p-2 rounded-lg ignore-drag">
-                                        <x-mary-button @click="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')"  icon="o-x-circle" :tooltip="$removeText"  class="btn-sm btn-ghost btn-circle" />
-                                        <x-mary-button @click="crop('image-{{ $modelName().'.'.$key  }}-{{ $uuid }}')" icon="o-scissors" :tooltip="$cropText"  class="btn-sm btn-ghost btn-circle" />
+                                        <x-mary-button @click="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')" @touchend.prevent="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')" icon="o-x-circle" :tooltip="$removeText"  class="btn-sm btn-ghost btn-circle" />
+                                        <x-mary-button @click="crop('image-{{ $modelName().'.'.$key  }}-{{ $uuid }}')" @touchend.prevent="crop('image-{{ $modelName().'.'.$key }}-{{ $uuid }}')" icon="o-scissors" :tooltip="$cropText"  class="btn-sm btn-ghost btn-circle" />
                                     </div>
                                 </div>
                             @endforeach


### PR DESCRIPTION
On real iOS devices (Safari/Chrome), @click does not reliably trigger when used inside custom components such as <x-mary-button>, especially within absolute-positioned elements.

This change adds `@touchend.prevent` to the relevant buttons in the ImageLibrary component to ensure full touch compatibility on iOS devices.

This does not affect behavior on other platforms and maintains backward compatibility.
Tested on iPhone (Safari and Chrome).