### PR TITLE
Extend x-card with body-class option.

### DIFF
--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -22,7 +22,7 @@ class Card extends Component
         public mixed $menu = null,
         public mixed $actions = null,
         public mixed $figure = null,
-        public string $bodyClass = 'grow-1'
+        public ?string $bodyClass = 'null'
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
     }

--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -22,6 +22,7 @@ class Card extends Component
         public mixed $menu = null,
         public mixed $actions = null,
         public mixed $figure = null,
+        public string $bodyClass = 'grow-1'
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
@@ -90,7 +91,7 @@ class Card extends Component
                         </div>
                     @endif
 
-                    <div class="grow-1">
+                    <div @class([$bodyClass ?: 'grow-1'])>
                         {{ $slot }}
                     </div>
 

--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -91,7 +91,7 @@ class Card extends Component
                         </div>
                     @endif
 
-                    <div @class([$bodyClass ?: 'grow-1'])>
+                    <div @class([ 'grow-1', $bodyClass ])>
                         {{ $slot }}
                     </div>
 


### PR DESCRIPTION
This tweak allows users to override the {{slot}} div with their own custom classes.

By default, the body-class is null and will work like default, only providing 'grow-1'.

If body-class is specified, ~~the body div will not use 'grow-1' and only use the specified classes.~~ the body div is appended to, including 'grow-1'.

When using the x-card, i've ran into a problem where overflow-y-auto doesn't work when using the {{slot}} of the x-card.  This ended up being the fix.

Thanks for your work on MaryUI!