### PR TITLE
Group: allow changing the color of the selected option

### DIFF
--- a/src/View/Components/Group.php
+++ b/src/View/Components/Group.php
@@ -16,6 +16,7 @@ class Group extends Component
         public ?string $label = null,
         public ?string $hint = null,
         public ?string $hintClass = 'fieldset-label',
+        public ?string $checkedClass = 'neutral',
         public ?string $optionValue = 'id',
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
@@ -67,7 +68,7 @@ class Group extends Component
                                     {{ $attributes->whereStartsWith('wire:model') }}
                                     {{
                                         $attributes->class([
-                                            "join-item btn [&:checked]:btn-neutral",
+                                            "join-item btn [&:checked]:btn-$checkedClass",
                                             "!border-l-base-100" => data_get($option, 'disabled')
                                         ])
                                     }}


### PR DESCRIPTION
This update adds support for customizing the color of the selected option within the `Group` component.

It works seamlessly with Tailwind's background color system, including utility classes like bg-primary, bg-secondary, and any standalone background color (e.g., bg-red-500, bg-green-200, etc.).

To use it, simply pass the utility class name (without the bg- prefix) to the `checked-class` attribute.
For example: `checked-class="primary"` will apply bg-primary to the selected option.