### PR TITLE
Pin: add `no-gap` attribute

### DIFF
--- a/src/View/Components/Pin.php
+++ b/src/View/Components/Pin.php
@@ -114,7 +114,7 @@ class Pin extends Component
                                     @endif
                                     {{
                                         $attributes->whereDoesntStartWith('wire')->class([
-                                            "input input-border !min-w-6 max-w-12 p-0 font-black text-xl text-center",
+                                            "input input-border min-w-6 max-w-12 p-0 font-bold text-xl text-center",
                                             "join-item" => $noGap,
                                             "!input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
                                         ])


### PR DESCRIPTION
This PR adds 2 ways pins can be made more flexible in regard to their width.
The reason for that change is that the narrowest screens currently only allow 5-6 characters to appear before overflowing, which is too short in the (possibly rare) scenario where a developer requires more (I personally use 8 on my website).

The 2 changes are independent but work well together too:
 1. Pin elements are no more constrained to the `w-12` class.
     Now, pins have `min-w-6 max-w-12` to allow more chances for a control to fit in a narrow layout/screen. Each individual pin is also given the `p-0` class, otherwise letters would be truncated.
 1. A new option, `no-gap` has been added to create a join group.
 This removes the `gap-3` applied between elements, which instantly allows gives it a lot of space

FYI: `min-w-6` is the absolute minimum width that can fit a capital `W`, which, per my tests, is the widest character I get.
I'm personally not a fan of `font-black`, preferring `font-bold` to it but well, as far as characters' width is concerned, it makes little difference.

----

The following code creates 4 pins that overflow their parent div (hence take as little width as possible) + 1 no-gap pin:
```
<div class="flex flex-col gap-8">
    <div class="flex flex-col w-20 gap-8">
        <x-pin wire:model="pin" size="26" />
        <x-pin wire:model="pin" size="26" />
        <x-pin wire:model="pin" size="10" />
        <x-pin wire:model="pin" size="30" />
    </div>
    <x-pin wire:model="pin" size="20" no-gap />
</div>
```

And they look like this, field for visual appreciation of how much room they effectively allow:

<img width="1606" height="461" alt="image" src="https://github.com/user-attachments/assets/ef5417fc-05b5-4238-ae1f-f6c72186c95c" />

----

PS: For comparison, with `font-bold` instead of `font-black` (not in the PR but just saying):

<img width="1737" height="496" alt="image" src="https://github.com/user-attachments/assets/6d26a169-3011-44af-9af1-4b711cbc642a" />
