### PR TITLE
Input: add `password-icon-tabindex`

### DIFF
--- a/src/View/Components/Password.php
+++ b/src/View/Components/Password.php
@@ -26,7 +26,7 @@ class Password extends Component
         // Password
         public ?string $passwordIcon = 'o-eye-slash',
         public ?string $passwordVisibleIcon = 'o-eye',
-        public ?bool $noTabStop = false,
+        public ?bool $passwordIconTabindex = false,
         public ?bool $right = false,
         public ?bool $onlyPassword = false,
 
@@ -131,7 +131,7 @@ class Password extends Component
                                     <x-mary-button
                                         x-on:click="hidden = !hidden"
                                         class="btn-ghost btn-xs btn-circle -m-1"
-                                        :tabindex="$noTabStop ? -1 : null"
+                                        :tabindex="$passwordIconTabindex ? null : -1"
                                     >
                                         <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="w-4 h-4 opacity-40" />
                                         <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="w-4 h-4 opacity-40" />
@@ -162,8 +162,8 @@ class Password extends Component
                                 @elseif($placeToggleRight())
                                     <x-mary-button
                                         x-on:click="hidden = !hidden"
-                                        @class(["btn-ghost btn-xs btn-circle -m-1", "!end-9" => $clearable])>
-                                        :tabindex="$noTabStop ? -1 : null"
+                                        @class(["btn-ghost btn-xs btn-circle -m-1", "!end-9" => $clearable])
+                                        :tabindex="$passwordIconTabindex ? null : -1"
                                     >
                                         <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="w-4 h-4 opacity-40" />
                                         <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="w-4 h-4 opacity-40" />

--- a/src/View/Components/Password.php
+++ b/src/View/Components/Password.php
@@ -26,6 +26,7 @@ class Password extends Component
         // Password
         public ?string $passwordIcon = 'o-eye-slash',
         public ?string $passwordVisibleIcon = 'o-eye',
+        public ?bool $noTabStop = false,
         public ?bool $right = false,
         public ?bool $onlyPassword = false,
 
@@ -127,7 +128,11 @@ class Password extends Component
                                 @if($icon)
                                     <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 opacity-40" />
                                 @elseif($placeToggleLeft())
-                                    <x-mary-button x-on:click="hidden = !hidden" class="btn-ghost btn-xs btn-circle -m-1">
+                                    <x-mary-button
+                                        x-on:click="hidden = !hidden"
+                                        class="btn-ghost btn-xs btn-circle -m-1"
+                                        :tabindex="$noTabStop ? -1 : null"
+                                    >
                                         <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="w-4 h-4 opacity-40" />
                                         <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="w-4 h-4 opacity-40" />
                                     </x-mary-button>
@@ -155,7 +160,11 @@ class Password extends Component
                                 @if($iconRight)
                                     <x-mary-icon :name="$iconRight" @class(["pointer-events-none w-4 h-4 opacity-40", "!end-10" => $clearable]) />
                                 @elseif($placeToggleRight())
-                                    <x-mary-button x-on:click="hidden = !hidden" @class(["btn-ghost btn-xs btn-circle -m-1", "!end-9" => $clearable])>
+                                    <x-mary-button
+                                        x-on:click="hidden = !hidden"
+                                        @class(["btn-ghost btn-xs btn-circle -m-1", "!end-9" => $clearable])>
+                                        :tabindex="$noTabStop ? -1 : null"
+                                    >
                                         <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="w-4 h-4 opacity-40" />
                                         <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="w-4 h-4 opacity-40" />
                                     </x-mary-button>


### PR DESCRIPTION
Following discussions in #953, this PR implements the no-tab-stop parameter for password fields separately.

Closes #942 