### PR TITLE
Stat: fix overflow on small screens

### DIFF
--- a/src/View/Components/Stat.php
+++ b/src/View/Components/Stat.php
@@ -47,7 +47,7 @@ class Stat extends Component
                             </div>
                         @endif
 
-                        <div class="text-left rtl:text-right">
+                        <div class="text-left rtl:text-right truncate">
                             @if($title)
                                 <div class="text-xs text-base-content/50 whitespace-nowrap">{{ $title }}</div>
                             @endif


### PR DESCRIPTION
added the `truncate` utility class to the description area of the `stat` component to prevent layout overflow on small screens.
Without `truncate`, long descriptions can break the layout or overflow out of the stat box.

<img width="289" height="123" alt="Screenshot 2025-07-26 143146" src="https://github.com/user-attachments/assets/9f5e04a5-a35c-4be4-8837-cebc491a5706" />
