### PR TITLE
Choices/ChoicesOffline: fix Firefox issue

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -263,7 +263,7 @@ class Choices extends Component
 
                                         {{
                                             $attributes->whereStartsWith('class')->class([
-                                                "select w-full min-h-fit pl-2.5",
+                                                "select w-full min-h-[var(--size)] h-auto pl-2.5",
                                                 "join-item" => $prepend || $append,
                                                 "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                                 "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -270,7 +270,7 @@ class ChoicesOffline extends Component
 
                                         {{
                                             $attributes->whereStartsWith('class')->class([
-                                                "select w-full min-h-fit pl-2.5",
+                                                "select w-full min-h-[var(--size)] h-auto pl-2.5",
                                                 "join-item" => $prepend || $append,
                                                 "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                                 "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError


### PR DESCRIPTION
Closes #963 

Hello, I have added a fix for the issue in the `Choices` & `Choices Offline` component as mentioned in #963. I used `--size` as the value for min-height instead of the plain `min-h-fit` to define the initial height. Additionally, I added `h-auto` so the height automatically adjusts based on the number of selected choices.

Examples:

**Edge** 
<img width="1919" height="984" alt="image" src="https://github.com/user-attachments/assets/fe16a47c-6650-4fd4-a25f-60043327e322" />


**Firefox**
<img width="1917" height="1033" alt="image" src="https://github.com/user-attachments/assets/16a6f7c7-1324-40c5-9975-9bfb0cbe1056" />
