### PR TITLE
Spotlight: disable browser autocomplete

### DIFF
--- a/src/View/Components/Spotlight.php
+++ b/src/View/Components/Spotlight.php
@@ -138,6 +138,7 @@ class Spotlight extends Component
                                             id="{{ $uuid }}"
                                             x-model="value"
                                             x-ref="spotSearch"
+                                            name="spotSearch"
                                             placeholder=" {{ $searchText }}"
                                             class="w-full input my-2 border-none outline-none shadow-none border-transparent  focus:shadow-none focus:outline-none focus:border-transparent"
                                             @focus="$el.focus()"


### PR DESCRIPTION
Add a `name` to the input field, so the browser can't autocomplete it.