### PR TITLE
fix: render placeholder without HTML escaping

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -136,7 +136,7 @@ class Input extends Component
                                     {{-- INPUT --}}
                                     <input
                                         id="{{ $uuid }}"
-                                        placeholder="{{ $attributes->get('placeholder') }} "
+                                        :placeholder="$attributes->get('placeholder')"
 
                                         @if($attributes->has('autofocus') && $attributes->get('autofocus') == true)
                                             autofocus


### PR DESCRIPTION
The placeholder attribute was being HTML-escaped when rendered via  {{ $attributes->get('placeholder') }}, causing apostrophes (')  to appear as &#039;. Switched to :placeholder binding to preserve  raw text output.

https://github.com/user-attachments/assets/13f01c82-a08c-4ffd-8879-958dc969f2ee

