### PR TITLE
Dropdown: Add `scroll` and `max-height` properties

### DIFF
--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -17,6 +17,8 @@ class Dropdown extends Component
         public ?bool $right = false,
         public ?bool $top = false,
         public ?bool $noXAnchor = false,
+        public ?bool $scroll = false,
+        public ?string $maxHeight = 'max-h-96',
         // Slots
         public mixed $trigger = null
     ) {
@@ -54,6 +56,8 @@ class Dropdown extends Component
                     @class([
                         'p-2','shadow','menu','z-[1]','border-[length:var(--border)]','border-base-content/10','bg-base-100', 'rounded-box','w-auto','min-w-max',
                         'dropdown-content' => $noXAnchor,
+                        $maxHeight => $scroll,
+                        'overflow-y-auto' => $scroll,
                     ])
                     @click="open = false"
                     @if(!$noXAnchor)


### PR DESCRIPTION
Occasionally I've come across dropdowns that i need to cut off to a certain height to make them look good.  This change adds a new property to Dropdown that adds an overflow and fixed height to allow the inner elements to be scrollable. 

Default behavior is the same.

Adding only 'scroll' will add the overflow and a default max height.  

Specifying scroll and max-height allows you to customize the height of the menu.

<img width="1024" height="821" alt="Screenshot 2025-10-28 130132" src="https://github.com/user-attachments/assets/fe76f06c-b332-4376-ab7c-97cbb43d7445" />

<img width="1029" height="811" alt="Screenshot 2025-10-28 130140" src="https://github.com/user-attachments/assets/82298467-c4de-4443-87e1-8775ad89ce08" />

<img width="1042" height="815" alt="Screenshot 2025-10-28 130144" src="https://github.com/user-attachments/assets/7cc8e2cb-4cc0-468d-9fc6-0a75fdefc095" />
