### PR TITLE
Toast: Add progress support

### DIFF
--- a/src/Exceptions/ToastException.php
+++ b/src/Exceptions/ToastException.php
@@ -25,7 +25,7 @@ class ToastException extends Exception
 
     protected bool $preventDefault = true;
 
-    protected bool $progress = false;
+    protected bool $noProgress = false;
 
     protected ?string $progressClass = null;
 
@@ -37,7 +37,7 @@ class ToastException extends Exception
         string $icon = 'o-information-circle',
         string $css = 'alert-info',
         int $timeout = 3000,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ): self {
         $instance = new self(message: $title, code: 500);
@@ -49,7 +49,7 @@ class ToastException extends Exception
         $instance->icon = $icon;
         $instance->css = $css;
         $instance->timeout = $timeout;
-        $instance->progress = $progress;
+        $instance->noProgress = $noProgress;
         $instance->progressClass = $progressClass;
 
         return $instance;
@@ -62,7 +62,7 @@ class ToastException extends Exception
         string $icon = 'o-information-circle',
         string $css = 'alert-info',
         int $timeout = 3000,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ): self {
         return self::typedMessage(
@@ -73,7 +73,7 @@ class ToastException extends Exception
             icon: $icon,
             css: $css,
             timeout: $timeout,
-            progress: $progress,
+            noProgress: $noProgress,
             progressClass: $progressClass,
         );
     }
@@ -85,7 +85,7 @@ class ToastException extends Exception
         string $icon = 'o-check-circle',
         string $css = 'alert-success',
         int $timeout = 3000,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ): self {
         return self::typedMessage(
@@ -96,7 +96,7 @@ class ToastException extends Exception
             icon: $icon,
             css: $css,
             timeout: $timeout,
-            progress: $progress,
+            noProgress: $noProgress,
             progressClass: $progressClass,
         );
     }
@@ -108,7 +108,7 @@ class ToastException extends Exception
         string $icon = 'o-x-circle',
         string $css = 'alert-error',
         int $timeout = 3000,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ): self {
         return self::typedMessage(
@@ -119,7 +119,7 @@ class ToastException extends Exception
             icon: $icon,
             css: $css,
             timeout: $timeout,
-            progress: $progress,
+            noProgress: $noProgress,
             progressClass: $progressClass,
         );
     }
@@ -131,7 +131,7 @@ class ToastException extends Exception
         string $icon = 'o-exclamation-triangle',
         string $css = 'alert-warning',
         int $timeout = 3000,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ): self {
         return self::typedMessage(
@@ -142,7 +142,7 @@ class ToastException extends Exception
             icon: $icon,
             css: $css,
             timeout: $timeout,
-            progress: $progress,
+            noProgress: $noProgress,
             progressClass: $progressClass,
         );
     }
@@ -168,7 +168,7 @@ class ToastException extends Exception
                     'css' => $this->css,
                     'timeout' => $this->timeout,
 
-                    'progress' => $this->progress,
+                    'noProgress' => $this->noProgress,
                     'progressClass' => $this->progressClass,
                 ],
                 'prevent_default' => $this->preventDefault

--- a/src/Traits/Toast.php
+++ b/src/Traits/Toast.php
@@ -15,7 +15,7 @@ trait Toast
         string $css = 'alert-info',
         int $timeout = 3000,
         ?string $redirectTo = null,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ) {
         $toast = [
@@ -26,7 +26,7 @@ trait Toast
             'icon' => Blade::render("<x-mary-icon class='w-7 h-7' name='".$icon."' />"),
             'css' => $css,
             'timeout' => $timeout,
-            'progress' => $progress,
+            'noProgress' => $noProgress,
             'progressClass' => $progressClass,
         ];
 
@@ -48,10 +48,10 @@ trait Toast
         string $css = 'alert-success',
         int $timeout = 3000,
         ?string $redirectTo = null,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ) {
-        return $this->toast('success', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $progress, $progressClass);
+        return $this->toast('success', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass);
     }
 
     public function warning(
@@ -62,10 +62,10 @@ trait Toast
         string $css = 'alert-warning',
         int $timeout = 3000,
         ?string $redirectTo = null,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ) {
-        return $this->toast('warning', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $progress, $progressClass);
+        return $this->toast('warning', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass);
     }
 
     public function error(
@@ -76,10 +76,10 @@ trait Toast
         string $css = 'alert-error',
         int $timeout = 3000,
         ?string $redirectTo = null,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ) {
-        return $this->toast('error', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $progress, $progressClass);
+        return $this->toast('error', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass);
     }
 
     public function info(
@@ -90,9 +90,9 @@ trait Toast
         string $css = 'alert-info',
         int $timeout = 3000,
         ?string $redirectTo = null,
-        bool $progress = false,
+        bool $noProgress = false,
         ?string $progressClass = null,
     ) {
-        return $this->toast('info', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $progress, $progressClass);
+        return $this->toast('info', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass);
     }
 }

--- a/src/View/Components/Toast.php
+++ b/src/View/Components/Toast.php
@@ -48,7 +48,7 @@ class Toast extends Component
                         },
                 
                         startProgress() {
-                            if (!this.toast.progress) return;
+                            if (this.toast.noProgress) return;
                 
                             const intervalRefreshRate = 8;
                             const step = this.progress / (this.remaining / intervalRefreshRate);
@@ -119,7 +119,7 @@ class Toast extends Component
                             </div>
                         </div>
                         <progress
-                            x-show="toast.progress"
+                            x-show="!toast.noProgress"
                             class="-mt-3 h-1 w-full progress"
                             :class="toast.progressClass"
                             :max="maxProgress"


### PR DESCRIPTION
This is the improvement mentionned in #976.

This PR adds a progress bar under the Toast component by default. The progress bar will show up with the start value of **100**, and decrease until **0** according to the duration of the toast, just like this :

<img width="255" height="86" alt="image" src="https://github.com/user-attachments/assets/4c417e31-46eb-4fde-b52e-052569884a59" />

The progress bar can be removed by setting the `noProgress` variable to true like this : `$this->*toastType*(noProgress: true)`

Moreover, i added a feature that allows the timeout (along with the progress bar) to stop when hovering the toast, and resume when leaving the hover.

Since the progress bar is the `<progress>` component from **DaisyUI**, we can use the [progress classes](https://daisyui.com/components/progress/) to customize the it with the `progressClass` variable like this : `$this->*toastType*(progressClass: 'progress-primary')`

Note that `progressClass` is set to `null` by default, so the default color of the progress bar will be **neutral**.