### PR TITLE
Choices: make searchable input react to Cyrillic by switching from keydown to input debounce

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -333,7 +333,7 @@ class Choices extends Component
                                                  @endif
 
                                                 @if($searchable)
-                                                    @keydown.debounce.{{ $debounce }}="search($el.value, $event)"
+                                                    @input.debounce.{{ $debounce }}="search($el.value, $event)"
                                                 @endif
                                              />
                                         </div>


### PR DESCRIPTION
Searchable field didn't trigger search() on Cyrillic input because keydown events were not firing properly.
Replaced @keydown.debounce with @input.debounce to fix it.
