### PR TITLE
MenuItem: improve support for using route parameter

### DIFF
--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -19,6 +19,7 @@ class MenuItem extends Component
         public ?string $spinner = null,
         public ?string $link = null,
         public ?string $route = null,
+        public ?array $routeParams = [],
         public ?bool $external = false,
         public ?bool $noWireNavigate = false,
         public ?string $badge = null,
@@ -41,9 +42,20 @@ class MenuItem extends Component
         return $this->spinner;
     }
 
+    public function getHref(): ?string
+    {
+        if ($this->route) {
+            return route($this->route, $this->routeParams);
+        }
+
+        return $this->link;
+    }
+
     public function routeMatches(): bool
     {
-        if ($this->link == null) {
+        $href = $this->getHref();
+
+        if ($href == null) {
             return false;
         }
 
@@ -79,8 +91,8 @@ class MenuItem extends Component
                             ])
                         }}
 
-                        @if($link)
-                            href="{{ $link }}"
+                        @if($getHref())
+                            href="{{ $getHref() }}"
 
                             @if($external)
                                 target="_blank"


### PR DESCRIPTION
This modification allows for use with the (named) route parameter only without having to set the link explicitly. 
Previously if you didn't set a link, the route wouldn't activate if on that page. Also the route parameter was ignored when constructing the link.

There's now also support for route parameters.

```
<x-menu-item title="Dashboard" route="dashboard" /> // Or with parameters
<x-menu-item title="User Profile" route="users.show" :route-params="['id' => 1]" />
```