### PR TITLE
Header: add `use-h1` attribute

### DIFF
--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -11,6 +11,8 @@ class Header extends Component
 {
     public string $anchor = '';
 
+    public string $titleTag = 'div';
+
     public function __construct(
         public ?string $title = null,
         public ?string $subtitle = null,
@@ -30,6 +32,7 @@ class Header extends Component
         public mixed $actions = null,
     ) {
         $this->anchor = Str::slug($title);
+        $this->titleTag = $useH1 ? 'h1' : 'div';
     }
 
     public function progressTarget(): ?string
@@ -47,39 +50,21 @@ class Header extends Component
                 <div id="{{ $anchor }}" {{ $attributes->class(["mb-10", "mary-header-anchor" => $withAnchor]) }}>
                     <div class="flex flex-wrap gap-5 justify-between items-center">
                         <div>
-                            @if($useH1)
-                                <h1 @class(["flex", "items-center", "$size font-extrabold", "pl-2" => $icon, is_string($title) ? '' : $title?->attributes->get('class') ]) >
-                                    @if($withAnchor)
-                                        <a href="#{{ $anchor }}">
-                                    @endif
+                            {!! "<{$titleTag}" !!} @class(["flex", "items-center", "$size font-extrabold", is_string($title) ? '' : $title?->attributes->get('class') ]) >
+                                @if($withAnchor)
+                                    <a href="#{{ $anchor }}">
+                                @endif
 
-                                    @if($icon)
-                                        <x-mary-icon name="{{ $icon }}" class="{{ $iconClasses }}" />
-                                    @endif
+                                @if($icon)
+                                    <x-mary-icon name="{{ $icon }}" class="{{ $iconClasses }}" />
+                                @endif
 
-                                    {{ $title }}
+                                <span @class(["ml-2" => $icon])>{{ $title }}</span>
 
-                                    @if($withAnchor)
-                                        </a>
-                                    @endif
-                                </h1>
-                            @else
-                                <div @class(["flex", "items-center", "$size font-extrabold", is_string($title) ? '' : $title?->attributes->get('class') ]) >
-                                    @if($withAnchor)
-                                        <a href="#{{ $anchor }}">
-                                    @endif
-
-                                    @if($icon)
-                                        <x-mary-icon name="{{ $icon }}" class="{{ $iconClasses}}" />
-                                    @endif
-
-                                    <span @class(["ml-2" => $icon])>{{ $title }}</span>
-
-                                    @if($withAnchor)
-                                        </a>
-                                    @endif
-                                </div>
-                            @endif
+                                @if($withAnchor)
+                                    </a>
+                                @endif
+                            {!! "</{$titleTag}>" !!}
 
                             @if($subtitle)
                                 <div @class(["text-base-content/50 text-sm mt-1", is_string($subtitle) ? '' : $subtitle?->attributes->get('class') ]) >


### PR DESCRIPTION
Good day,

Supporting #1002, I have modified the Header component view file to include an optional use-h1 attribute.
If the attribute is passed to the component, the render will be done using `<h1></h1>` tags.
This is to support SEO optimization. 

Usage: `<x-header title="Welcome!" size="text-4xl" subtitle="This is a welcome page" class="!mb-5" use-h1 />`

From my test, there is no breaking of existing styling/layout, and you can still override default h1 styling references with custom class attributes.

The html rendering looks correct as well: 
`<div id="welcome" class="mb-10 !mb-5"><div class="flex flex-wrap gap-5 justify-between items-center"><div><h1 class="flex items-center text-4xl font-extrabold " >Welcome!</h1><div class="text-base-content/50 text-sm mt-1 " >This is a welcome page</div></div><div class="flex items-center gap-3 " > </div></div>`

Let me know your thoughts.
Joey

Note: sorry for the bad readability of my PR, I have difficulties with the Markdown editor.
Note 2: following advice, new PR to commit from a branch, and not from the main branch on my fork.


Closes #1002 