### PR TITLE
Added autocomplete attribute to Input/Password components

### DIFF
--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -23,6 +23,7 @@ class Input extends Component
         public ?bool $clearable = false,
         public ?bool $money = false,
         public ?string $locale = 'en-US',
+        public ?string $autocomplete = null,
 
         // Slots
         public mixed $prepend = null,
@@ -140,6 +141,10 @@ class Input extends Component
 
                                         @if($attributes->has('autofocus') && $attributes->get('autofocus') == true)
                                             autofocus
+                                        @endif
+
+                                        @if($autocomplete)
+                                            autocomplete="{{ $autocomplete }}"
                                         @endif
 
                                         @if($money)

--- a/src/View/Components/Password.php
+++ b/src/View/Components/Password.php
@@ -22,6 +22,7 @@ class Password extends Component
         public ?string $suffix = null,
         public ?bool $inline = false,
         public ?bool $clearable = false,
+        public ?string $autocomplete = null,
 
         // Password
         public ?string $passwordIcon = 'o-eye-slash',
@@ -146,6 +147,10 @@ class Password extends Component
 
                                     @if($attributes->has('autofocus') && $attributes->get('autofocus') == true)
                                         autofocus
+                                    @endif
+
+                                    @if($autocomplete)
+                                        autocomplete="{{ $autocomplete }}"
                                     @endif
 
                                     {{ $attributes->except('type')->merge() }}


### PR DESCRIPTION
Good day,

Autocomplete attribute has become standards when designing web forms.
Especially, when using MaryUI components to design a simple log-in form, Chrome Dev Console will throw: connexion:1 [DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq) <input id=​"marye6ee36000329b1f79d37240464ded95cpassword" placeholder=​" " x-bind:type=​"hidden ? 'password' :​ 'text'" wire:model=​"password" type=​"password">​flex

Added feature to pass on an optional autocomplete attribute and value to the following components:
- Input
- Password