### PR TITLE
Card: remove hard coded card border radius

### DIFF
--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -43,7 +43,7 @@ class Card extends Component
                     {{
                         $attributes
                             ->merge(['wire:key' => $uuid ])
-                            ->class(['card bg-base-100 rounded-lg p-5', 'shadow-xs' => $shadow])
+                            ->class(['card bg-base-100 p-5', 'shadow-xs' => $shadow])
                     }}
                 >
                     @if($figure)


### PR DESCRIPTION
Issue mentionned in #1023.

Removing the hard coded card border radius to match the daisyUI theme border radius in `css var(--radius-box)`

Tested locally with many themes and working (cyberpunk for the showcase here) :

_With hard-coded radius :_
<img width="1517" height="319" alt="image" src="https://github.com/user-attachments/assets/3599f675-8677-433e-8519-c743409cf0d5" />

_Without hard coded radius :_
<img width="1513" height="322" alt="image" src="https://github.com/user-attachments/assets/69207ba2-07eb-4764-9945-3d8f80f28316" />

Closes #1023 
