### PR TITLE
Tabs: remove old workaround

### DIFF
--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -33,13 +33,6 @@ class Tabs extends Component
                                     @else
                                         @entangle($attributes->wire('model'))
                                     @endif
-                                 ,
-                                 init() {
-                                     // Fix weird issue when navigating back
-                                     document.addEventListener('livewire:navigating', () => {
-                                         document.querySelectorAll('.tab').forEach(el =>  el.remove());
-                                     });
-                                 }
                         }"
                         class="{{ $tabsClass }}"
                         x-class="font-semibold pb-1 border-b-[length:var(--border)] border-b-base-content/50 border-b-base-content/10 flex overflow-x-auto scrollbar-hide relative w-full"


### PR DESCRIPTION
Remove old workaround, needed in previous versions of Livewire/Alpine.

Currently, back browser navigation breaks tabs.