### PR TITLE
Spotlight: expose result search with `x-ref`

### DIFF
--- a/src/View/Components/Spotlight.php
+++ b/src/View/Components/Spotlight.php
@@ -171,7 +171,7 @@ class Spotlight extends Component
 
                             <!-- RESULTS  -->
                             <div class="-mx-1 mt-1" @click="close()" @keydown.enter="close()" x-ref="spotResults">
-                                <template x-for="(item, index) in results" :key="index" >
+                                <template x-for="(item, index) in results" :key="index">
                                     <!-- ITEM -->
                                     <a x-bind:href="item.link" class="mary-spotlight-element" @if(!$noWireNavigate) wire:navigate @endif tabindex="0">
                                         <div class="p-3 hover:bg-base-200 border-t-[length:var(--border)] border-t-base-content/10" >


### PR DESCRIPTION
Useful if you are using custom slots and need to manually control the focus.

```html
<x-spotlight>
   <div>
      <!--- focus on the first list element -->
      <x-checkbox @change="$refs.spotResults.children[1]?.focus()" />
  </div>
</x-spotlight>
```