### PR TITLE
DateTime: Fix missing "join" class when there are prepend/append elements

### DIFF
--- a/src/View/Components/DateTime.php
+++ b/src/View/Components/DateTime.php
@@ -70,7 +70,7 @@ class DateTime extends Component
                             <span class="font-semibold">{{ $label }}</span>
                         @endif
 
-                        <div class="w-full">
+                        <div @class(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}


### PR DESCRIPTION
Fix of the issue mentionned in #1025.

Closes #1025 