### PR TITLE
Carousel: accessibility improvements

### DIFF
--- a/src/View/Components/Carousel.php
+++ b/src/View/Components/Carousel.php
@@ -138,6 +138,7 @@ class Carousel extends Component
                                 class="w-full h-full inset-0 object-cover"
                                 src="{{ data_get($slide, 'image') }}"
                                 alt="{{ data_get($slide, 'alt') }}"
+                                loading="{{ data_get($slide, 'lazy') ? 'lazy' : 'eager' }}"
                                 fetchpriority="{{ $loop->first ? 'high' : 'low' }}"
                             />
                         </div>


### PR DESCRIPTION
Improvements mentionned in #1022 :

Added a check on the lazy attribute of a slide. If there's a lazy attribute, the image will be set to lazy loading. If not, it will be set to eager loading (default behaviour).

Improvements mentionned in #882 :

To get along accessibility standards, i've made a few changes.

- Unlabelled buttons have now the `aria-label` attribute, which includes the previous/next buttons but also the buttons to select the slide.
- Added a check on the alt attribute to add images an alternative text.
- Increased the gap of the buttons for slide selection (was throwing a warning about accessibility because the gap was too tight).

Closes #1022

