### PR TITLE
Modal: add custom header slot

### DIFF
--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -10,14 +10,14 @@ class Modal extends Component
 {
     public function __construct(
         public ?string $id = '',
-        public ?string $title = null,
+        public mixed $title = null,
+        public ?string $subtitle = null,
         public ?string $boxClass = null,
         public ?bool $separator = false,
         public ?bool $persistent = false,
         public ?bool $withoutTrapFocus = false,
 
         // Slots
-        public mixed $header = null,
         public ?string $actions = null
     ) {
         //
@@ -56,12 +56,17 @@ class Modal extends Component
                             </form>
                         @endif
 
-                        @if($header)
-                            <div>
-                                {{ $header }}
+                        @if(is_string($title))
+                            <div class="mb-5">
+                                <h3 class="font-bold text-lg">{{ $title }}</h3>
+                                @isset($subtitle)
+                                    <div class="text-base-content/50 text-sm mt-1">
+                                        {{ $subtitle }}
+                                    </div>
+                                @endisset
                             </div>
-                        @elseif($title)
-                            <h3 class="font-bold text-lg mb-5">{{ $title }}</h3>
+                        @else
+                            {{ $title }}
                         @endif
 
                         <div>

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -11,13 +11,13 @@ class Modal extends Component
     public function __construct(
         public ?string $id = '',
         public ?string $title = null,
-        public ?string $subtitle = null,
         public ?string $boxClass = null,
         public ?bool $separator = false,
         public ?bool $persistent = false,
         public ?bool $withoutTrapFocus = false,
 
         // Slots
+        public mixed $header = null,
         public ?string $actions = null
     ) {
         //
@@ -56,8 +56,12 @@ class Modal extends Component
                             </form>
                         @endif
 
-                        @if($title)
-                            <x-mary-header :title="$title" :subtitle="$subtitle" size="text-xl" :separator="$separator" class="!mb-5" />
+                        @if($header)
+                            <div>
+                                {{ $header }}
+                            </div>
+                        @elseif($title)
+                            <h3 class="font-bold text-lg mb-5">{{ $title }}</h3>
                         @endif
 
                         <div>


### PR DESCRIPTION
Mentionned in #901.

Allows the user to either set a title with the default DaisyUI style with the `title` attribute, or a custom title slot if more customization is needed.

**Breaking change :** none

Closes #901