### PR TITLE
Table: add `fluent` attribute

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -39,6 +39,7 @@ class Table extends Component
         public mixed $emptyText = 'No records found.',
         public string $containerClass = 'overflow-x-auto',
         public ?bool $noHover = false,
+        public ?bool $fluent = false,
 
         // Slots
         public mixed $actions = null,
@@ -381,7 +382,7 @@ class Table extends Component
                                                     <a href="{{ $redirectLink($row) }}" wire:navigate class="block py-3 px-4">
                                                 @endif
 
-                                                {{ ${"cell_".$temp_key}($row)  }}
+                                                {{ ${"cell_".$temp_key}($fluent ? fluent($row) : $row) }}
 
                                                 @if($hasLink($header))
                                                     </a>
@@ -412,7 +413,7 @@ class Table extends Component
                                 @if($expandable)
                                     <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="!bg-inherit" :class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || 'hidden'">
                                         <td :colspan="colspanSize">
-                                            {{ $expansion($row) }}
+                                            {{ $expansion($fluent ? fluent($row) : $row) }}
                                         </td>
                                     </tr>
                                 @endif


### PR DESCRIPTION
Transforms scoped variables into a `Illuminate\Support\Fluent`  object. Useful if you are not using eloquent or resources collections. 

```blade
<x-table ... fluent>
  @scope('cell_phones', $user)
     {{-- Now `$user` is a fluent object --}}
  @endscope
</x-table>
```

```blade
<x-table ... fluent>
  @scope('expansion', $user )
     {{-- Now `$user` is a fluent object --}}
  @endscope
</x-table>
```