### PR TITLE
DatePicker: attached flatpickr cleanup

### DIFF
--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -224,7 +224,7 @@ class DatePicker extends Component
                                     x-on:livewire:navigating.window="instance.destroy();"
                                     class="w-full"
                                 >
-                                    <input x-ref="input" {{ $attributes->merge(['type' => 'text']) }} />
+                                    <input x-ref="input" {{ $attributes->merge(['type' => 'date']) }} />
                                 </div>
 
                                 {{-- CLEAR ICON --}}


### PR DESCRIPTION
mentioned in [#1040](https://github.com/robsontenorio/mary/issues/1040)

destroy the attached flatpickr instance on component rerender

Closes #1040