### PR TITLE
Choices/Choices-offline: add escape values conditional

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -40,6 +40,7 @@ class Choices extends Component
         public ?string $optionSubLabel = '',
         public ?string $optionAvatar = 'avatar',
         public ?bool $valuesAsString = false,
+        public ?bool $escapeValues = false,
         public ?string $height = 'max-h-64',
         public Collection|array $options = new Collection(),
         public ?string $noResultText = 'No results found.',
@@ -93,6 +94,12 @@ class Choices extends Component
         $value = data_get($option, $this->optionValue);
 
         if ($this->valuesAsString) {
+            return "'$value'";
+        }
+
+        if ($this->escapeValues) {
+            $value = addslashes($value);
+
             return "'$value'";
         }
 

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -38,6 +38,7 @@ class ChoicesOffline extends Component
         public ?string $optionSubLabel = '',
         public ?string $optionAvatar = 'avatar',
         public ?bool $valuesAsString = false,
+        public ?bool $escapeValues = false,
         public ?string $height = 'max-h-64',
         public Collection|array $options = new Collection(),
         public ?string $noResultText = 'No results found.',
@@ -91,6 +92,12 @@ class ChoicesOffline extends Component
         $value = data_get($option, $this->optionValue);
 
         if ($this->valuesAsString) {
+            return "'$value'";
+        }
+
+        if ($this->escapeValues) {
+            $value = addslashes($value);
+
             return "'$value'";
         }
 


### PR DESCRIPTION
Hi, this request adds an 'escapeValues' conditional to prevent malformed ids in AlpineJS (eg. values containing single/double quotes etc.) when creating choice options on the fly by mapping unique values. Refer [Issue #1048](https://github.com/robsontenorio/mary/issues/1048#issue-3868372908).