### PR TITLE
Toast: fix progress bar class

### DIFF
--- a/src/View/Components/Toast.php
+++ b/src/View/Components/Toast.php
@@ -114,7 +114,7 @@ class Toast extends Component
                     @mary-toast.window="start($event.detail.toast)"
                 >
                     <div
-                        class="toast !whitespace-normal rounded-md fixed cursor-pointer z-[999] overflow-hidden"
+                        class="toast !whitespace-normal rounded-box fixed cursor-pointer z-[999] overflow-hidden"
                         :class="toast.position || '{{ $position }}'"
                         x-show="show"
                         @mouseenter="pause()"


### PR DESCRIPTION
The recent progress bar addition to the Toast component has a fixed class of  ```rounded-md```, which works fine for the default DaisyUI theme, however, other themes with different rounded classes don't match (see below). 

**theme: bumblebee**
<img width="186" height="79" alt="Toast-progress-bug" src="https://github.com/user-attachments/assets/8d869e81-8677-4803-bd43-bd2e2231a57e" />


**Fix:** 
Changing the main toast class from ```rounded-md``` to ```rounded-box``` makes it dynamic and matches other theme settings, as seen below:

**theme: light**
<img width="183" height="74" alt="Toast-progress-fix-light" src="https://github.com/user-attachments/assets/86dd57e4-dcbd-40f1-8538-589886fcd370" />


**theme: bumblebee**
<img width="185" height="78" alt="Toast-progress-fix-bumblebee" src="https://github.com/user-attachments/assets/b226037b-17b7-4ad0-87e4-a1eb23898438" />