### PR TITLE
Editor: support `content_css` configuration

### DIFF
--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -101,7 +101,10 @@ class Editor extends Component
                                     images_upload_url: uploadUrl,
                                     readonly: {{ json_encode($attributes->get('readonly') || $attributes->get('disabled')) }},
                                     skin: document.documentElement.getAttribute('class') == 'dark' ? 'oxide-dark' : 'oxide',
-                                    content_css: document.documentElement.getAttribute('class') == 'dark' ? 'dark' : 'default',
+                                    content_css: [
+                                        document.documentElement.getAttribute('class') == 'dark' ? 'dark' : 'default',
+                                        @if(isset($config['content_css'])) '{{ $config['content_css'] }}' @endif
+                                    ],
 
                                     @if($attributes->get('disabled'))
                                         content_style: 'body { opacity: 50% }',


### PR DESCRIPTION
Support `content_css` configuration


```html
<x-editor
    label="Content"
    wire:model="content"
    config="['min_height' => 800 , 'content_css' => Vite::asset('resources/css/tinymce.css')]"
/>
```

-----------


Create `resources/css/tinymce.css`

```css
@reference "./app.css";

/********************************************
 You need to declare daisyUI here
*********************************************/

/* dasyUI */
@plugin "daisyui" {
    themes: light --default, dark --prefersdark;
}

/********************************************
 Editor style
*********************************************/

body {
    @apply bg-inherit text-error
}
```

Add to `vite.config.js`

```js
input: ["resources/css/app.css", "resources/css/tinymce.css", "resources/js/app.js"],        
```
