### PR TITLE
Tabs: fix `back`/`forward` browser button

### DIFF
--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -39,9 +39,10 @@ class Tabs extends Component
                     >
                         <!-- TAB LABELS -->
                         <div class="{{ $labelDivClass }}">
-                            <template x-for="tab in tabs">
+                            <template x-for="tab in tabs" :key="tab.name">
                                 <a
                                     role="tab"
+                                    x-init="if (typeof tab == 'undefined') $el.remove()"
                                     x-html="tab.label"
                                      @click="tab.disabled ? null: selected = tab.name"
                                     :class="{ '{{ $activeClass }} tab-active': selected === tab.name, 'hidden': tab.hidden }"


### PR DESCRIPTION
In recent versions of Livewire v4 (maybe AlpineJS), if you navigate to any page and then hit the browser's "back"/"forward"/"back" button, this issue will occur.

This is quite frustrating and is not a permanent solution. While it prevents the visual issue, it still displays warnings in the browser console.

If you find a better solution, please submit a PR.

---

<img width="891" height="369" alt="image" src="https://github.com/user-attachments/assets/9d72df16-c745-4c15-9923-c962ea43a8a7" />
