### PR TITLE
Calendar: upgrade to v3

### DIFF
--- a/src/View/Components/Calendar.php
+++ b/src/View/Components/Calendar.php
@@ -38,7 +38,7 @@ class Calendar extends Component
             'displayDatesOutside' => false,
             'styles' => [
                 'calendar' => 'vc w-fit',
-                'grid' => 'vc-grid justify-around',
+                'grid' => 'vc-grid justify-center',
                 'column' => 'vc-column !min-w-fit !max-w-fit',
             ]
         ], $this->config));


### PR DESCRIPTION
## Breaking change

Upgrade to latest VanillaCalendarPro v3 version.


```html
<script src="https://cdn.jsdelivr.net/npm/vanilla-calendar-pro@3.1.0/index.min.js"></script>
<link href="https://cdn.jsdelivr.net/npm/vanilla-calendar-pro@3.1.0/styles/index.min.css" rel="stylesheet">
```

Actually you just need to update the CDN scripts.
Additionally if you use the `$config` object, take a look at VanillaCalendarPro api docs.
If you don't, you are good to go.