### PR TITLE
Badge: add `icon` and `icon-right` 

### DIFF
--- a/src/View/Components/Badge.php
+++ b/src/View/Components/Badge.php
@@ -13,6 +13,8 @@ class Badge extends Component
     public function __construct(
         public ?string $id = null,
         public ?string $value = null,
+        public ?string $icon = null,
+        public ?string $iconRight = null,
 
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
@@ -22,7 +24,22 @@ class Badge extends Component
     {
         return <<<'HTML'
                 <div {{ $attributes->class(["badge"])}}>
-                    {{ $value }}
+                    <!-- ICON -->
+                    @if($icon)
+                        <x-mary-icon :name="$icon" />
+                    @endif
+
+                    <!-- VALUE / SLOT -->
+                    @if($value)
+                        {{ $value }}
+                    @else
+                        {{ $slot }}
+                    @endif
+
+                    <!-- ICON RIGHT -->
+                    @if($iconRight)
+                        <x-mary-icon :name="$iconRight" />
+                    @endif
                 </div>
             HTML;
     }

--- a/src/View/Components/Badge.php
+++ b/src/View/Components/Badge.php
@@ -26,7 +26,7 @@ class Badge extends Component
                 <div {{ $attributes->class(["badge"])}}>
                     <!-- ICON -->
                     @if($icon)
-                        <x-mary-icon :name="$icon" />
+                        <x-mary-icon :name="$icon" class="h-4 w-4" />
                     @endif
 
                     <!-- VALUE / SLOT -->
@@ -38,7 +38,7 @@ class Badge extends Component
 
                     <!-- ICON RIGHT -->
                     @if($iconRight)
-                        <x-mary-icon :name="$iconRight" />
+                        <x-mary-icon :name="$iconRight" class="h-4 w-4" />
                     @endif
                 </div>
             HTML;


### PR DESCRIPTION
## Summary

- Add optional `icon` and `iconRight` props to the Badge component, following the same convention used by the [Button component](https://mary-ui.com/docs/components/button#icons)

## Usage

```blade
<x-badge value="Active" icon="o-check" />

<x-badge value="Warning" icon-right="o-exclamation-triangle" />
```