### PR TITLE
All input components: add `popover` option

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -45,6 +45,12 @@ class Choices extends Component
         public Collection|array $options = new Collection(),
         public ?string $noResultText = 'No results found.',
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -241,6 +247,18 @@ class Choices extends Component
 
                                     @if($attributes->get('required'))
                                         <span class="text-error">*</span>
+                                    @endif
+                                    
+                                    {{-- INPUT POPOVER --}}
+                                    @if($popover)
+                                        <x-mary-popover offset="5" position="top-start">
+                                            <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                                <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                            </x-slot:trigger>
+                                            <x-slot:content class="{{ $popoverContentClass }}">
+                                                {{ $popover }}
+                                            </x-slot:content>
+                                        </x-mary-popover>
                                     @endif
                                 </legend>
                             @endif

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -43,6 +43,12 @@ class ChoicesOffline extends Component
         public Collection|array $options = new Collection(),
         public ?string $noResultText = 'No results found.',
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error label-text-alt p-1',
@@ -247,6 +253,18 @@ class ChoicesOffline extends Component
 
                                     @if($attributes->get('required'))
                                         <span class="text-error">*</span>
+                                    @endif
+                                    
+                                    {{-- INPUT POPOVER --}}
+                                    @if($popover)
+                                        <x-mary-popover offset="5" position="top-start">
+                                            <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                                <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                            </x-slot:trigger>
+                                            <x-slot:content class="{{ $popoverContentClass }}">
+                                                {{ $popover }}
+                                            </x-slot:content>
+                                        </x-mary-popover>
                                     @endif
                                 </legend>
                             @endif

--- a/src/View/Components/Colorpicker.php
+++ b/src/View/Components/Colorpicker.php
@@ -22,6 +22,12 @@ class Colorpicker extends Component
         public ?bool $inline = false,
         public ?bool $clearable = false,
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -69,6 +75,18 @@ class Colorpicker extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -22,6 +22,12 @@ class DatePicker extends Component
         public ?bool $clearable = false,
         public ?array $config = [],
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Slots
         public mixed $prepend = null,
         public mixed $append = null,
@@ -116,6 +122,18 @@ class DatePicker extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/DateTime.php
+++ b/src/View/Components/DateTime.php
@@ -19,6 +19,12 @@ class DateTime extends Component
         public ?string $hintClass = 'fieldset-label',
         public ?bool $inline = false,
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Slots
         public mixed $prepend = null,
         public mixed $append = null,
@@ -60,6 +66,18 @@ class DateTime extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -22,6 +22,12 @@ class Editor extends Component
         public ?bool $gplLicense = false,
         public ?array $config = [],
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -78,6 +84,18 @@ class Editor extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -24,6 +24,12 @@ class File extends Component
         public ?array $cropConfig = [],
         public ?string $cropMimeType = "image/png",
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -144,6 +150,18 @@ class File extends Component
 
                                 @if($attributes->get('required'))
                                     <span class="text-error">*</span>
+                                @endif
+                                
+                                {{-- INPUT POPOVER --}}
+                                @if($popover)
+                                    <x-mary-popover offset="5" position="top-start">
+                                        <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                            <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        </x-slot:trigger>
+                                        <x-slot:content class="{{ $popoverContentClass }}">
+                                            {{ $popover }}
+                                        </x-slot:content>
+                                    </x-mary-popover>
                                 @endif
                             </legend>
                         @endif

--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -29,6 +29,12 @@ class ImageLibrary extends Component
         public ?array $cropConfig = [],
         public Collection $preview = new Collection(),
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
@@ -141,6 +147,18 @@ class ImageLibrary extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -23,8 +23,12 @@ class Input extends Component
         public ?bool $clearable = false,
         public ?bool $money = false,
         public ?string $locale = 'en-US',
+
+	    // Popover
         public ?string $popover = null,
         public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
 
         // Slots
         public mixed $prepend = null,
@@ -91,10 +95,10 @@ class Input extends Component
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
-                                    <x-slot:trigger>
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
                                         <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
                                     </x-slot:trigger>
-                                    <x-slot:content>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
                                     </x-slot:content>
                                 </x-mary-popover>

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -21,6 +21,12 @@ class Markdown extends Component
         public ?string $folder = 'markdown',
         public ?array $config = [],
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -92,6 +98,18 @@ class Markdown extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -22,6 +22,12 @@ class Radio extends Component
         public Collection|array $options = new Collection(),
         public ?bool $inline = false,
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -53,6 +59,18 @@ class Radio extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Range.php
+++ b/src/View/Components/Range.php
@@ -18,6 +18,12 @@ class Range extends Component
         public ?int $min = 0,
         public ?int $max = 100,
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -49,6 +55,18 @@ class Range extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -27,6 +27,12 @@ class Select extends Component
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Slots
         public mixed $prepend = null,
         public mixed $append = null,
@@ -67,6 +73,18 @@ class Select extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/SelectGroup.php
+++ b/src/View/Components/SelectGroup.php
@@ -25,6 +25,12 @@ class SelectGroup extends Component
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Slots
         public mixed $prepend = null,
         public mixed $append = null,
@@ -65,6 +71,18 @@ class SelectGroup extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -22,6 +22,12 @@ class Tags extends Component
         public ?string $prefix = null,
         public ?string $suffix = null,
 
+	    // Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Slots
         public mixed $prepend = null,
         public mixed $append = null,
@@ -138,6 +144,18 @@ class Tags extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -17,6 +17,12 @@ class Textarea extends Component
         public ?string $hintClass = 'fieldset-label',
         public ?bool $inline = false,
 
+		// Popover
+        public ?string $popover = null,
+        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverTriggerClass = '',
+        public ?string $popoverContentClass = '',
+
         // Validations
         public ?string $errorField = null,
         public ?string $errorClass = 'text-error',
@@ -53,6 +59,18 @@ class Textarea extends Component
 
                             @if($attributes->get('required'))
                                 <span class="text-error">*</span>
+                            @endif
+                            
+                            {{-- INPUT POPOVER --}}
+                            @if($popover)
+                                <x-mary-popover offset="5" position="top-start">
+                                    <x-slot:trigger class="{{ $popoverTriggerClass }}">
+                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="{{ $popoverContentClass }}">
+                                        {{ $popover }}
+                                    </x-slot:content>
+                                </x-mary-popover>
                             @endif
                         </legend>
                     @endif


### PR DESCRIPTION
Adds popover support to all form components (previously only available for input elements);
Adds support for setting custom classes for popovers;
Usage:
`<x-input popover popover-trigger-class="opacity-50" popover-content-class="max-w-50" />`