### PR TITLE
Misc: update padding class from 'pl' to 'ps' and 'pr' to 'pe'

### DIFF
--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -45,7 +45,7 @@ class Choices extends Component
         public Collection|array $options = new Collection(),
         public ?string $noResultText = 'No results found.',
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
         public ?string $popoverIcon = "o-question-mark-circle",
         public ?string $popoverTriggerClass = '',
@@ -289,7 +289,7 @@ class Choices extends Component
 
                                         {{
                                             $attributes->whereStartsWith('class')->class([
-                                                "select w-full min-h-[var(--size)] h-auto pl-2.5",
+                                                "select w-full min-h-[var(--size)] h-auto ps-2.5",
                                                 "join-item" => $prepend || $append,
                                                 "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                                 "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -43,7 +43,7 @@ class ChoicesOffline extends Component
         public Collection|array $options = new Collection(),
         public ?string $noResultText = 'No results found.',
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
         public ?string $popoverIcon = "o-question-mark-circle",
         public ?string $popoverTriggerClass = '',
@@ -295,7 +295,7 @@ class ChoicesOffline extends Component
 
                                         {{
                                             $attributes->whereStartsWith('class')->class([
-                                                "select w-full min-h-[var(--size)] h-auto pl-2.5",
+                                                "select w-full min-h-[var(--size)] h-auto ps-2.5",
                                                 "join-item" => $prepend || $append,
                                                 "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                                 "!select-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError

--- a/src/View/Components/Pagination.php
+++ b/src/View/Components/Pagination.php
@@ -35,7 +35,7 @@ class Pagination extends Component
         return <<<'HTML'
             <div class="mary-table-pagination">
                 <div {{ $attributes->class(["mb-4 border-t-[length:var(--border)] border-t-base-content/5"]) }}></div>
-                <div class="justify-between md:flex md:flex-row w-auto md:w-full items-center overflow-y-auto pl-2 pr-2 relative">
+                <div class="justify-between md:flex md:flex-row w-auto md:w-full items-center overflow-y-auto ps-2 pe-2 relative">
                     @if($isShowable())
                     <div class="flex flex-row justify-center md:justify-start mb-2 md:mb-0 py-1">
                         <select id="{{ $uuid }}" @if(!empty($modelName())) wire:model.live="{{ $modelName() }}" @endif

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -22,7 +22,7 @@ class Tags extends Component
         public ?string $prefix = null,
         public ?string $suffix = null,
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
         public ?string $popoverIcon = "o-question-mark-circle",
         public ?string $popoverTriggerClass = '',
@@ -182,7 +182,7 @@ class Tags extends Component
 
                                 {{
                                     $attributes->whereStartsWith('class')->class([
-                                        "input w-full h-fit pl-2.5",
+                                        "input w-full h-fit ps-2.5",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                         "!input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError


### PR DESCRIPTION
Updated physical padding classes (pl-*, pr-*) to logical equivalents (ps-*, pe-*) in:

- Choices.php
- ChoicesOffline.php
- Pagination.php
- Tags.php

This fixes UI alignment issues in RTL layouts by making padding direction respect text flow.
The fix keeps LTR behavior unchanged while ensuring components render properly in mirrored RTL interfaces.