### PR TITLE
feat(modal): add `position` prop, default to `middle`

### DIFF
--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -16,6 +16,7 @@ class Modal extends Component
         public ?bool $separator = false,
         public ?bool $persistent = false,
         public ?bool $withoutTrapFocus = false,
+        public ?string $position = 'middle',
 
         // Slots
         public ?string $actions = null
@@ -27,7 +28,7 @@ class Modal extends Component
     {
         return <<<'HTML'
                 <dialog
-                    {{ $attributes->except('wire:model')->class(["modal"]) }}
+                    {{ $attributes->except('wire:model')->class(["modal", "modal-{$position}" => $position]) }}
 
                     @if($id)
                         id="{{ $id }}"


### PR DESCRIPTION
## What

Adds a `position` prop to `<x-modal>` mapping to daisyUI's position modifiers: `top`, `middle`, `bottom`, `start`, `end`. Default is `middle`.

```blade
<x-modal wire:model="show" />                  {{-- modal modal-middle --}}
<x-modal wire:model="show" position="top" />   {{-- modal modal-top --}}
<x-modal wire:model="show" position="" />      {{-- modal (previous behavior) --}}
```

## Why

Mary currently renders `<dialog class="modal">` with no position class. daisyUI's bare `.modal-box` uses `max-height: 100vh` with no margin — only the `modal-middle/top/bottom` variants get the `calc(100vh - 5em)` buffer.

On mobile, `100vh` extends under the browser chrome, so when content overflows, the close button (`absolute top-2`) and `modal-action` row are clipped:

**Before - close button hidden at top:**
<img width="216" height="480" alt="image" src="https://github.com/user-attachments/assets/3fd37a3d-a58f-478a-bd62-2fa36406a5fb" />


**After**
<img  width="216" height="480" alt="image" src="https://github.com/user-attachments/assets/74b6f14e-8f1b-45b7-bedd-ce0e5ecb8194" />
