### PR TITLE
Rework Tab/Tabs

### DIFF
--- a/src/View/Components/Tab.php
+++ b/src/View/Components/Tab.php
@@ -4,7 +4,6 @@ namespace Mary\View\Components;
 
 use Closure;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\View\Component;
 
 class Tab extends Component
@@ -18,60 +17,45 @@ class Tab extends Component
         public ?string $icon = null,
         public bool $disabled = false,
         public bool $hidden = false,
+        public ?string $badge = null,
+        public ?string $badgeClass = null,
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
-    }
-
-    public function tabLabel(string $label): string
-    {
-        $fromLabel = $this->label ? $this->label : $label;
-
-        if ($this->icon) {
-            return Blade::render("
-                <x-mary-icon name='" . $this->icon . "' @class([
-                'me-2',
-                'whitespace-nowrap',
-                'text-base-content/30 cursor-not-allowed' => '$this->disabled'
-                ])>
-                    <x-slot:label>
-                        {$fromLabel}
-                    </x-slot:label>
-                </x-mary-icon>
-            ");
-        }
-
-        return Blade::render("
-            <div @class([
-                'whitespace-nowrap',
-                'text-base-content/30 cursor-not-allowed' => '$this->disabled'
-                ])>
-                {$fromLabel}
-            </div>
-        ");
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                    <a
-                        class="hidden tab"
-                        :class="{ 'tab-active': selected === '{{ $name }}' }"
-                        data-name="{{ $name }}"
-                        x-init="
-                                const newItem = { name: '{{ $name }}', label: {{ json_encode($tabLabel($label)) }}, disabled: {{ $disabled ? 'true' : 'false' }}, hidden: {{ $hidden ? 'true' : 'false' }} };
-                                const index = tabs.findIndex(item => item.name === '{{ $name }}');
-                                index !== -1 ? tabs[index] = newItem : tabs.push(newItem);
+                    @aware(['lift', 'box', 'labelClass', 'contentClass', 'activeClass'])
 
-                                Livewire.hook('morph.removed', ({el}) => {
-                                    if (el.getAttribute('data-name') == '{{ $name }}'){
-                                        tabs = tabs.filter(i => i.name !== '{{ $name }}')
-                                    }
-                                })
-                            "
-                    ></a>
+                    <div>
+                        <label
+                            @class([
+                                "tab flex flex-nowrap items-center gap-3 whitespace-nowrap px-4",
+                                $labelClass,
+                                "hidden" => $hidden,
+                                "tab-disabled" => $disabled
+                             ])
+                            :class="{ '{{ $activeClass }}': selected === '{{ $name }}' }"
+                        >
+                            <input id="{{ ($id ?? $uuid).$name }}" type="radio" name="{{ ($id ?? $uuid).$name }}" value="{{ $name }}" x-model="selected" />
 
-                    <div x-show="selected === '{{ $name }}'" role="tabpanel" {{ $attributes->class("tab-content py-5 px-1") }}>
-                        {{ $slot }}
+                            @if($icon)
+                              <x-mary-icon :name="$icon"  />
+                            @endif
+
+                            {{ $label }}
+
+                            @if ($badge)
+                                <x-badge :value="$badge" @class(["badge-sm badge-soft", $badgeClass]) />
+                            @endif
+                        </label>
+                        <div
+                            x-show="selected == '{{ $name }}'"
+                            {{ $attributes->class(["tab-content py-5 px-3 border-t-base-content/10 block rounded-none", $contentClass]) }}
+                         >
+                            {{ $slot }}
+                        </div>
                     </div>
                 HTML;
     }

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -12,11 +12,10 @@ class Tabs extends Component
 
     public function __construct(
         public ?string $id = null,
-        public ?string $selected = null,
-        public string $labelClass = 'font-semibold pb-1',
-        public string $activeClass = 'border-b-[length:var(--border)] border-b-base-content/50',
-        public string $labelDivClass = 'border-b-[length:var(--border)] border-b-base-content/10 flex overflow-x-auto',
-        public string $tabsClass = 'relative w-full',
+        public ?string $labelClass = null,
+        public ?string $activeClass = null,
+        public ?string $contentClass = null,
+        public string $tabsClass = 'scrollbar-none flex-nowrap overflow-x-auto',
     ) {
         $this->uuid = "mary" . md5(serialize($this)) . $id;
     }
@@ -26,34 +25,38 @@ class Tabs extends Component
         return <<<'HTML'
                     <div
                         x-data="{
-                                tabs: [],
-                                selected:
-                                    @if($selected)
-                                        '{{ $selected }}'
-                                    @else
-                                        @entangle($attributes->wire('model'))
-                                    @endif
-                        }"
-                        class="{{ $tabsClass }}"
-                        x-class="font-semibold pb-1 border-b-[length:var(--border)] border-b-base-content/50 border-b-base-content/10 flex overflow-x-auto scrollbar-hide relative w-full"
-                    >
-                        <!-- TAB LABELS -->
-                        <div class="{{ $labelDivClass }}">
-                            <template x-for="tab in tabs" :key="tab.name">
-                                <a
-                                    role="tab"
-                                    x-init="if (typeof tab == 'undefined') $el.remove()"
-                                    x-html="tab.label"
-                                     @click="tab.disabled ? null: selected = tab.name"
-                                    :class="{ '{{ $activeClass }} tab-active': selected === tab.name, 'hidden': tab.hidden }"
-                                    class="tab {{ $labelClass }}"></a>
-                            </template>
-                        </div>
+                            selected: @entangle($attributes->wire('model')),
+                            init() {
+                                this.refresh();
+                                Livewire.hook('morphed', ({ el }) => this.refresh() );
+                            },
+                            refresh() {
+                                Array.from($refs.slot.children).forEach(tab => {
+                                    const label = tab.querySelector('label');
+                                    const content = tab.querySelector('.tab-content');
 
-                        <!-- TAB CONTENT -->
-                        <div role="tablist" {{ $attributes->except(['wire:model', 'wire:model.live'])->class(["block"]) }}>
+                                    if (label) {
+                                        $refs.labels.appendChild(label);
+                                    }
+
+                                    if (content) {
+                                        $refs.contents.appendChild(content);
+                                    }
+                                });
+                            }
+                        }"
+                        x-class="scrollbar-none flex-nowrap overflow-x-auto"
+                    >
+                        <!-- TABS -->
+                         <div x-ref="labels" {{ $attributes->except(['wire:model', 'wire:model.live'])->class(["tabs tabs-border", $tabsClass]) }}></div>
+
+                        <!--  CONTENTS -->
+                         <div x-ref="contents"></div>
+
+                        <!-- ORIGINAL DATA -->
+                         <div data-tab x-ref="slot">
                             {{ $slot }}
-                        </div>
+                         </div>
                     </div>
                 HTML;
     }


### PR DESCRIPTION
Rework the code to adopt a cleaner approach, considering the recent changes in DaisyUI and Tailwind CSS.

Closes #1093


## New

The `badge` and `badgeClass`  properties

<img width="847" height="645" alt="image" src="https://github.com/user-attachments/assets/ace0df05-6539-4db7-acba-f3de263d0fa3" />



## Breaking Change 🚨

The customization class names have changed

<img width="902" height="717" alt="image" src="https://github.com/user-attachments/assets/8743978b-ed9e-47f8-ae4a-ca9e8e7458ee" />