### PR TITLE
feat: add Tailwind CSS prefix support

### DIFF
--- a/config/mary.php
+++ b/config/mary.php
@@ -51,6 +51,13 @@ return [
     'class_source_path' => storage_path('framework/mary/classes.html'),
 
     /**
+     * Blade directories scanned for Mary class candidates.
+     */
+    'class_source_paths' => [
+        resource_path('views'),
+    ],
+
+    /**
      * Components settings
      */
     'components' => [

--- a/config/mary.php
+++ b/config/mary.php
@@ -35,11 +35,27 @@ return [
     'route_prefix' => '',
 
     /**
+     * Tailwind CSS prefix.
+     *
+     * This value must match the prefix configured in your Tailwind import.
+     * For example, use `tw` here with `@import "tailwindcss" prefix(tw)`.
+     */
+    'tailwind_prefix' => null,
+
+    /**
+     * Generated class source consumed by Tailwind CSS.
+     *
+     * Use a path inside your repository if the frontend is built in an
+     * environment where PHP is not available.
+     */
+    'class_source_path' => storage_path('framework/mary/classes.html'),
+
+    /**
      * Components settings
      */
     'components' => [
         'spotlight' => [
             'class' => 'App\Support\Spotlight',
-        ]
-    ]
+        ],
+    ],
 ];

--- a/src/ClassBuilder.php
+++ b/src/ClassBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Mary;
+
+use Illuminate\Support\Arr;
+use Stringable;
+
+class ClassBuilder implements Stringable
+{
+    /** @var array<int, string> */
+    protected array $pending = [];
+
+    public function __construct(protected ?string $prefix = null)
+    {
+        if ($prefix === null || trim($prefix) === '') {
+            $this->prefix = null;
+
+            return;
+        }
+
+        $this->prefix = str_ends_with($prefix, ':') || str_ends_with($prefix, '-')
+            ? $prefix
+            : $prefix . ':';
+    }
+
+    public function add(string|array|null $classes): static
+    {
+        $clone = clone $this;
+        $clone->pending[] = $this->prefix(Arr::toCssClasses($classes ?? ''));
+
+        return $clone;
+    }
+
+    public function addRaw(string|array|null $classes): static
+    {
+        $clone = clone $this;
+        $clone->pending[] = Arr::toCssClasses($classes ?? '');
+
+        return $clone;
+    }
+
+    public function __toString(): string
+    {
+        return implode(' ', array_filter($this->pending));
+    }
+
+    protected function prefix(string $classes): string
+    {
+        if ($classes === '' || $this->prefix === null) {
+            return $classes;
+        }
+
+        $prefix = $this->prefix;
+
+        return implode(' ', array_map(
+            fn (string $class): string => str_starts_with($class, $prefix) ? $class : $prefix . $class,
+            preg_split('/\s+/', trim($classes)) ?: []
+        ));
+    }
+}

--- a/src/Console/Commands/MaryBuildClassSourceCommand.php
+++ b/src/Console/Commands/MaryBuildClassSourceCommand.php
@@ -4,6 +4,9 @@ namespace Mary\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Mary\ClassBuilder;
+use Mary\Support\ClassCandidateExtractor;
+use Mary\Support\ClassSourceRegistry;
 use RuntimeException;
 
 class MaryBuildClassSourceCommand extends Command
@@ -12,24 +15,30 @@ class MaryBuildClassSourceCommand extends Command
 
     protected $description = 'Generate the static HTML source for Mary CSS classes';
 
+    public function __construct(protected ClassSourceRegistry $classSources)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         $prefix = config('mary.tailwind_prefix');
 
-        if (filled($prefix) && ! preg_match('/^[a-z]+$/', $prefix)) {
-            $this->components->error('The Mary Tailwind prefix must contain lowercase ASCII letters only.');
+        if (($prefix !== null && ! is_string($prefix))
+            || (is_string($prefix) && trim($prefix) !== '' && ! preg_match('/^[a-z]+[:-]?$/', $prefix))) {
+            $this->components->error('The Mary Tailwind prefix must contain lowercase ASCII letters and may end with : or -.');
 
             return self::FAILURE;
         }
 
         $path = $this->resolvePath($this->option('path') ?: config('mary.class_source_path'));
-        $classes = File::lines(__DIR__.'/../../../resources/classes.txt')
-            ->map(fn (string $class): string => trim($class))
-            ->filter()
-            ->unique()
-            ->sort()
-            ->map(fn (string $class): string => filled($prefix) ? $prefix.':'.$class : $class)
-            ->implode("\n");
+        $builder = new ClassBuilder($prefix);
+        $classes = ClassCandidateExtractor::fromPaths($this->classSources->all());
+        $classes = array_map(
+            fn (string $class): string => (string) $builder->add($class),
+            $classes
+        );
+        $classes = implode("\n", $classes);
 
         File::ensureDirectoryExists(dirname($path));
 

--- a/src/Console/Commands/MaryBuildClassSourceCommand.php
+++ b/src/Console/Commands/MaryBuildClassSourceCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Mary\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+class MaryBuildClassSourceCommand extends Command
+{
+    protected $signature = 'mary:build-class-source {--path= : Override the generated class source path}';
+
+    protected $description = 'Generate the static HTML source for Mary CSS classes';
+
+    public function handle(): int
+    {
+        $prefix = config('mary.tailwind_prefix');
+
+        if (filled($prefix) && ! preg_match('/^[a-z]+$/', $prefix)) {
+            $this->components->error('The Mary Tailwind prefix must contain lowercase ASCII letters only.');
+
+            return self::FAILURE;
+        }
+
+        $path = $this->resolvePath($this->option('path') ?: config('mary.class_source_path'));
+        $classes = File::lines(__DIR__.'/../../../resources/classes.txt')
+            ->map(fn (string $class): string => trim($class))
+            ->filter()
+            ->unique()
+            ->sort()
+            ->map(fn (string $class): string => filled($prefix) ? $prefix.':'.$class : $class)
+            ->implode("\n");
+
+        File::ensureDirectoryExists(dirname($path));
+
+        $temporaryPath = tempnam(dirname($path), 'mary-classes-');
+
+        if ($temporaryPath === false) {
+            throw new RuntimeException("Unable to create a temporary file in [{$path}].");
+        }
+
+        File::put($temporaryPath, "<!doctype html>\n<html>\n<body>\n{$classes}\n</body>\n</html>\n");
+
+        if (! rename($temporaryPath, $path)) {
+            File::delete($temporaryPath);
+
+            throw new RuntimeException("Unable to write Mary class source to [{$path}].");
+        }
+
+        $this->components->info("Mary class source generated at [{$path}].");
+
+        return self::SUCCESS;
+    }
+
+    protected function resolvePath(?string $path): string
+    {
+        if (blank($path)) {
+            throw new RuntimeException('Mary class source path is not configured.');
+        }
+
+        if (str_starts_with($path, DIRECTORY_SEPARATOR) || preg_match('/^[A-Za-z]:[\\\\\/]/', $path)) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+}

--- a/src/Mary.php
+++ b/src/Mary.php
@@ -2,6 +2,8 @@
 
 namespace Mary;
 
+use Mary\Support\ClassSourceRegistry;
+
 class Mary
 {
     public function classes(string|array|null $classes = null): ClassBuilder
@@ -9,5 +11,13 @@ class Mary
         $builder = new ClassBuilder(config('mary.tailwind_prefix'));
 
         return $classes === null ? $builder : $builder->add($classes);
+    }
+
+    /** @param  string|array<int, string>  $paths */
+    public function addClassSourcePath(string|array $paths): static
+    {
+        app(ClassSourceRegistry::class)->add($paths);
+
+        return $this;
     }
 }

--- a/src/Mary.php
+++ b/src/Mary.php
@@ -4,8 +4,10 @@ namespace Mary;
 
 class Mary
 {
-    public static function hello(): string
+    public function classes(string|array|null $classes = null): ClassBuilder
     {
-        return 'Hello!';
+        $builder = new ClassBuilder(config('mary.tailwind_prefix'));
+
+        return $classes === null ? $builder : $builder->add($classes);
     }
 }

--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\View\ComponentAttributeBag;
 use Mary\Console\Commands\MaryBootcampCommand;
 use Mary\Console\Commands\MaryBuildClassSourceCommand;
 use Mary\Console\Commands\MaryInstallCommand;
+use Mary\Support\ClassSourceRegistry;
 use Mary\View\Components\Accordion;
 use Mary\View\Components\Alert;
 use Mary\View\Components\Avatar;
@@ -90,7 +91,7 @@ class MaryServiceProvider extends ServiceProvider
         $this->registerComponents();
         $this->registerBladeDirectives();
 
-        $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
+        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
 
         // Publishing is only necessary when using the CLI.
         if ($this->app->runningInConsole()) {
@@ -255,7 +256,15 @@ class MaryServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/mary.php', 'mary');
+        $this->mergeConfigFrom(__DIR__.'/../config/mary.php', 'mary');
+
+        $this->app->singleton(ClassSourceRegistry::class, function () {
+            return new ClassSourceRegistry([
+                __DIR__.'/View/Components',
+                __DIR__.'/Traits/Toast.php',
+                ...config('mary.class_source_paths', []),
+            ]);
+        });
 
         // Register the service the package provides.
         $this->app->singleton('mary', fn () => new Mary);

--- a/src/MaryServiceProvider.php
+++ b/src/MaryServiceProvider.php
@@ -5,7 +5,9 @@ namespace Mary;
 use Arr;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\ComponentAttributeBag;
 use Mary\Console\Commands\MaryBootcampCommand;
+use Mary\Console\Commands\MaryBuildClassSourceCommand;
 use Mary\Console\Commands\MaryInstallCommand;
 use Mary\View\Components\Accordion;
 use Mary\View\Components\Alert;
@@ -195,6 +197,19 @@ class MaryServiceProvider extends ServiceProvider
     public function registerBladeDirectives(): void
     {
         $this->registerScopeDirective();
+        $this->registerClassDirective();
+    }
+
+    public function registerClassDirective(): void
+    {
+        Blade::directive('maryClass', function ($expression) {
+            return 'class="<?php echo e(app(\'mary\')->classes(' . $expression . ')); ?>"';
+        });
+
+        ComponentAttributeBag::macro('maryClass', function (string|array|null $classes) {
+            /** @var ComponentAttributeBag $this */
+            return $this->class((string) app('mary')->classes($classes));
+        });
     }
 
     public function registerScopeDirective(): void
@@ -243,9 +258,7 @@ class MaryServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/mary.php', 'mary');
 
         // Register the service the package provides.
-        $this->app->singleton('mary', function ($app) {
-            return new Mary();
-        });
+        $this->app->singleton('mary', fn () => new Mary);
     }
 
     /**
@@ -268,6 +281,10 @@ class MaryServiceProvider extends ServiceProvider
             __DIR__ . '/../config/mary.php' => config_path('mary.php'),
         ], 'mary.config');
 
-        $this->commands([MaryInstallCommand::class, MaryBootcampCommand::class]);
+        $this->commands([
+            MaryInstallCommand::class,
+            MaryBootcampCommand::class,
+            MaryBuildClassSourceCommand::class,
+        ]);
     }
 }

--- a/src/Support/ClassCandidateExtractor.php
+++ b/src/Support/ClassCandidateExtractor.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Mary\Support;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+
+class ClassCandidateExtractor
+{
+    /**
+     * Extract literal candidates passed to Mary's internal class APIs.
+     *
+     * @param  array<int, string>  $paths
+     * @return array<int, string>
+     */
+    public static function fromPaths(array $paths): array
+    {
+        $classes = [];
+
+        foreach (self::sourceFiles($paths) as $file) {
+            $source = file_get_contents($file);
+
+            if ($source === false) {
+                throw new RuntimeException("Unable to read Mary class source [{$file}].");
+            }
+
+            foreach (self::expressions($source) as $expression) {
+                foreach (self::candidateLiterals($expression) as $literal) {
+                    foreach (DynamicClassCandidateResolver::expand($literal, $source, $file) as $resolved) {
+                        foreach (preg_split('/\s+/', trim($resolved)) ?: [] as $class) {
+                            if ($class !== '') {
+                                $classes[] = $class;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        $classes = array_values(array_unique($classes));
+        sort($classes);
+
+        return $classes;
+    }
+
+    /** @return array<int, string> */
+    private static function sourceFiles(array $paths): array
+    {
+        $files = [];
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                $files[] = $path;
+
+                continue;
+            }
+
+            if (! is_dir($path)) {
+                throw new RuntimeException("Mary class source path [{$path}] does not exist.");
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
+            );
+
+            /** @var SplFileInfo $file */
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    $files[] = $file->getPathname();
+                }
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /** @return array<int, string> */
+    private static function expressions(string $source): array
+    {
+        preg_match_all(
+            '/(?:Mary::classes|app\([\'\"]mary[\'\"]\)->classes|@maryClass|->maryClass)\s*\(/',
+            $source,
+            $matches,
+            PREG_OFFSET_CAPTURE
+        );
+
+        $expressions = [];
+
+        foreach ($matches[0] as [$match, $offset]) {
+            $open = $offset + strlen($match) - 1;
+            $call = self::parenthesized($source, $open);
+
+            if ($call !== null) {
+                [$expression, $close] = $call;
+                $expressions[] = $expression;
+                array_push($expressions, ...self::chainedAddExpressions($source, $close + 1));
+            }
+        }
+
+        return $expressions;
+    }
+
+    /** @return array{string, int}|null */
+    private static function parenthesized(string $source, int $open): ?array
+    {
+        $depth = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = $open; $index < $length; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+            } elseif ($character === '(') {
+                $depth++;
+            } elseif ($character === ')' && --$depth === 0) {
+                return [substr($source, $open + 1, $index - $open - 1), $index];
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array<int, string> */
+    private static function chainedAddExpressions(string $source, int $offset): array
+    {
+        $expressions = [];
+        $length = strlen($source);
+
+        while ($offset < $length) {
+            while ($offset < $length && ctype_space($source[$offset])) {
+                $offset++;
+            }
+
+            if (substr($source, $offset, 2) !== '->') {
+                break;
+            }
+
+            $offset += 2;
+
+            if (! preg_match('/\A([A-Za-z_][A-Za-z0-9_]*)\s*\(/', substr($source, $offset), $method)) {
+                break;
+            }
+
+            $open = $offset + strlen($method[0]) - 1;
+            $call = self::parenthesized($source, $open);
+
+            if ($call === null) {
+                break;
+            }
+
+            [$expression, $close] = $call;
+
+            if ($method[1] === 'add') {
+                $expressions[] = $expression;
+            }
+
+            $offset = $close + 1;
+        }
+
+        return $expressions;
+    }
+
+    /** @return array<int, string> */
+    private static function candidateLiterals(string $expression): array
+    {
+        $expression = trim($expression);
+
+        if (! str_starts_with($expression, '[') || ! str_ends_with($expression, ']')) {
+            return self::literals($expression);
+        }
+
+        $literals = [];
+
+        foreach (self::splitTopLevel(substr($expression, 1, -1), ',') as $item) {
+            $arrow = self::topLevelArrow($item);
+            $candidate = $arrow === null ? $item : substr($item, 0, $arrow);
+            array_push($literals, ...self::literals($candidate));
+        }
+
+        return $literals;
+    }
+
+    /** @return array<int, string> */
+    private static function splitTopLevel(string $source, string $separator): array
+    {
+        $parts = [];
+        $start = 0;
+        $round = 0;
+        $square = 0;
+        $curly = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = 0; $index < $length; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+
+                continue;
+            }
+
+            match ($character) {
+                '(' => $round++,
+                ')' => $round--,
+                '[' => $square++,
+                ']' => $square--,
+                '{' => $curly++,
+                '}' => $curly--,
+                default => null,
+            };
+
+            if ($character === $separator && $round === 0 && $square === 0 && $curly === 0) {
+                $parts[] = substr($source, $start, $index - $start);
+                $start = $index + 1;
+            }
+        }
+
+        $parts[] = substr($source, $start);
+
+        return $parts;
+    }
+
+    private static function topLevelArrow(string $source): ?int
+    {
+        $round = 0;
+        $square = 0;
+        $curly = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = 0; $index < $length - 1; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+
+                continue;
+            }
+
+            match ($character) {
+                '(' => $round++,
+                ')' => $round--,
+                '[' => $square++,
+                ']' => $square--,
+                '{' => $curly++,
+                '}' => $curly--,
+                default => null,
+            };
+
+            if ($character === '=' && $source[$index + 1] === '>' && $round === 0 && $square === 0 && $curly === 0) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array<int, string> */
+    private static function literals(string $expression): array
+    {
+        $literals = [];
+        $depth = 0;
+        $length = strlen($expression);
+
+        for ($index = 0; $index < $length; $index++) {
+            $character = $expression[$index];
+
+            if ($character === '(') {
+                $depth++;
+
+                continue;
+            }
+
+            if ($character === ')') {
+                $depth--;
+
+                continue;
+            }
+
+            if ($character !== '\'' && $character !== '"') {
+                continue;
+            }
+
+            $quote = $character;
+            $literal = '';
+            $escaped = false;
+
+            for ($index++; $index < $length; $index++) {
+                $character = $expression[$index];
+
+                if ($escaped) {
+                    $literal .= '\\'.$character;
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    break;
+                } else {
+                    $literal .= $character;
+                }
+            }
+
+            if ($depth === 0) {
+                $literals[] = $quote === '\''
+                    ? str_replace(['\\\\', "\\'"], ['\\', "'"], $literal)
+                    : stripcslashes($literal);
+            }
+        }
+
+        return $literals;
+    }
+}

--- a/src/Support/ClassCandidateExtractor.php
+++ b/src/Support/ClassCandidateExtractor.php
@@ -82,8 +82,10 @@ class ClassCandidateExtractor
     /** @return array<int, string> */
     private static function expressions(string $source): array
     {
+        $source = self::withoutComments($source);
+
         preg_match_all(
-            '/(?:Mary::classes|app\([\'\"]mary[\'\"]\)->classes|@maryClass|->maryClass)\s*\(/',
+            '/(?:Mary\s*::\s*classes|app\s*\(\s*[\'\"]mary[\'\"]\s*\)\s*->\s*classes|@maryClass|->\s*maryClass)\s*\(/',
             $source,
             $matches,
             PREG_OFFSET_CAPTURE
@@ -103,6 +105,32 @@ class ClassCandidateExtractor
         }
 
         return $expressions;
+    }
+
+    private static function withoutComments(string $source): string
+    {
+        $source = preg_replace_callback(
+            '/\{\{--.*?--\}\}|<!--.*?-->/s',
+            fn (array $match): string => preg_replace('/[^\r\n]/', ' ', $match[0]) ?? $match[0],
+            $source
+        ) ?? $source;
+
+        $sanitized = '';
+
+        foreach (token_get_all($source) as $token) {
+            if (! is_array($token)) {
+                $sanitized .= $token;
+
+                continue;
+            }
+
+            [$type, $contents] = $token;
+            $sanitized .= in_array($type, [T_COMMENT, T_DOC_COMMENT], true)
+                ? (preg_replace('/[^\r\n]/', ' ', $contents) ?? $contents)
+                : $contents;
+        }
+
+        return $sanitized;
     }
 
     /** @return array{string, int}|null */
@@ -157,6 +185,10 @@ class ClassCandidateExtractor
 
             $offset += 2;
 
+            while ($offset < $length && ctype_space($source[$offset])) {
+                $offset++;
+            }
+
             if (! preg_match('/\A([A-Za-z_][A-Za-z0-9_]*)\s*\(/', substr($source, $offset), $method)) {
                 break;
             }
@@ -185,6 +217,15 @@ class ClassCandidateExtractor
     {
         $expression = trim($expression);
 
+        if (($ternary = self::topLevelTernary($expression)) !== null) {
+            [$question, $colon] = $ternary;
+
+            return [
+                ...self::candidateLiterals(substr($expression, $question + 1, $colon - $question - 1)),
+                ...self::candidateLiterals(substr($expression, $colon + 1)),
+            ];
+        }
+
         if (! str_starts_with($expression, '[') || ! str_ends_with($expression, ']')) {
             return self::literals($expression);
         }
@@ -198,6 +239,83 @@ class ClassCandidateExtractor
         }
 
         return $literals;
+    }
+
+    /** @return array{int, int}|null */
+    private static function topLevelTernary(string $source): ?array
+    {
+        $round = 0;
+        $square = 0;
+        $curly = 0;
+        $quote = null;
+        $escaped = false;
+        $question = null;
+        $nested = 0;
+        $length = strlen($source);
+
+        for ($index = 0; $index < $length; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+
+                continue;
+            }
+
+            match ($character) {
+                '(' => $round++,
+                ')' => $round--,
+                '[' => $square++,
+                ']' => $square--,
+                '{' => $curly++,
+                '}' => $curly--,
+                default => null,
+            };
+
+            if ($round !== 0 || $square !== 0 || $curly !== 0) {
+                continue;
+            }
+
+            if ($character === '?'
+                && ($source[$index - 1] ?? null) !== '?'
+                && ($source[$index + 1] ?? null) !== '?'
+                && substr($source, $index, 3) !== '?->') {
+                if ($question === null) {
+                    $question = $index;
+                } else {
+                    $nested++;
+                }
+
+                continue;
+            }
+
+            if ($question !== null
+                && $character === ':'
+                && ($source[$index - 1] ?? null) !== ':'
+                && ($source[$index + 1] ?? null) !== ':') {
+                if ($nested > 0) {
+                    $nested--;
+
+                    continue;
+                }
+
+                return [$question, $index];
+            }
+        }
+
+        return null;
     }
 
     /** @return array<int, string> */

--- a/src/Support/ClassCandidateExtractor.php
+++ b/src/Support/ClassCandidateExtractor.php
@@ -83,10 +83,11 @@ class ClassCandidateExtractor
     private static function expressions(string $source): array
     {
         $source = self::withoutComments($source);
+        $searchSource = self::callSearchSource($source);
 
         preg_match_all(
             '/(?:Mary\s*::\s*classes|app\s*\(\s*[\'\"]mary[\'\"]\s*\)\s*->\s*classes|@maryClass|->\s*maryClass)\s*\(/',
-            $source,
+            $searchSource,
             $matches,
             PREG_OFFSET_CAPTURE
         );
@@ -131,6 +132,47 @@ class ClassCandidateExtractor
         }
 
         return $sanitized;
+    }
+
+    private static function callSearchSource(string $source): string
+    {
+        $searchable = '';
+        $insideHeredoc = false;
+
+        foreach (token_get_all($source) as $token) {
+            if (! is_array($token)) {
+                $searchable .= $token;
+
+                continue;
+            }
+
+            [$type, $contents] = $token;
+
+            if ($type === T_START_HEREDOC) {
+                $insideHeredoc = true;
+                $searchable .= $contents;
+
+                continue;
+            }
+
+            if ($type === T_END_HEREDOC) {
+                $insideHeredoc = false;
+                $searchable .= $contents;
+
+                continue;
+            }
+
+            $isOrdinaryString = $type === T_CONSTANT_ENCAPSED_STRING
+                || ($type === T_ENCAPSED_AND_WHITESPACE && ! $insideHeredoc);
+            $isMaryContainerKey = $type === T_CONSTANT_ENCAPSED_STRING
+                && in_array($contents, ["'mary'", '"mary"'], true);
+
+            $searchable .= $isOrdinaryString && ! $isMaryContainerKey
+                ? (preg_replace('/[^\r\n]/', ' ', $contents) ?? $contents)
+                : $contents;
+        }
+
+        return $searchable;
     }
 
     /** @return array{string, int}|null */
@@ -215,30 +257,226 @@ class ClassCandidateExtractor
     /** @return array<int, string> */
     private static function candidateLiterals(string $expression): array
     {
-        $expression = trim($expression);
+        $expression = self::unwrapParentheses(trim($expression));
+
+        if (($coalesced = self::splitTopLevelCoalescence($expression)) !== null) {
+            $literals = [];
+
+            foreach ($coalesced as $candidate) {
+                array_push($literals, ...self::candidateLiterals($candidate));
+            }
+
+            return $literals;
+        }
 
         if (($ternary = self::topLevelTernary($expression)) !== null) {
             [$question, $colon] = $ternary;
+            $whenTrue = substr($expression, $question + 1, $colon - $question - 1);
+
+            if (trim($whenTrue) === '') {
+                $whenTrue = substr($expression, 0, $question);
+            }
 
             return [
-                ...self::candidateLiterals(substr($expression, $question + 1, $colon - $question - 1)),
+                ...self::candidateLiterals($whenTrue),
                 ...self::candidateLiterals(substr($expression, $colon + 1)),
             ];
         }
 
-        if (! str_starts_with($expression, '[') || ! str_ends_with($expression, ']')) {
+        if (($matchResults = self::matchResults($expression)) !== null) {
+            $literals = [];
+
+            foreach ($matchResults as $result) {
+                array_push($literals, ...self::candidateLiterals($result));
+            }
+
+            return $literals;
+        }
+
+        $arrayContents = null;
+
+        if (str_starts_with($expression, '[') && str_ends_with($expression, ']')) {
+            $arrayContents = substr($expression, 1, -1);
+        } elseif (preg_match('/\Aarray\s*\(/', $expression, $match)) {
+            $open = strlen($match[0]) - 1;
+            $call = self::parenthesized($expression, $open);
+
+            if ($call !== null && $call[1] === strlen($expression) - 1) {
+                $arrayContents = $call[0];
+            }
+        }
+
+        if ($arrayContents === null) {
+            if (preg_match('/\A\$(?:this->)?[A-Za-z_][A-Za-z0-9_]*\z/', $expression)) {
+                return [$expression];
+            }
+
+            if (preg_match('/\A\$(?:this->)?[A-Za-z_][A-Za-z0-9_]*\s*\([^{}]*\)\z/s', $expression)) {
+                return ['{'.$expression.'}'];
+            }
+
             return self::literals($expression);
         }
 
         $literals = [];
 
-        foreach (self::splitTopLevel(substr($expression, 1, -1), ',') as $item) {
+        foreach (self::splitTopLevel($arrayContents, ',') as $item) {
             $arrow = self::topLevelArrow($item);
             $candidate = $arrow === null ? $item : substr($item, 0, $arrow);
-            array_push($literals, ...self::literals($candidate));
+            array_push($literals, ...self::candidateLiterals($candidate));
         }
 
         return $literals;
+    }
+
+    private static function unwrapParentheses(string $expression): string
+    {
+        while (str_starts_with($expression, '(')) {
+            $call = self::parenthesized($expression, 0);
+
+            if ($call === null || $call[1] !== strlen($expression) - 1) {
+                break;
+            }
+
+            $expression = trim($call[0]);
+        }
+
+        return $expression;
+    }
+
+    /** @return array<int, string>|null */
+    private static function splitTopLevelCoalescence(string $source): ?array
+    {
+        $parts = [];
+        $start = 0;
+        $round = 0;
+        $square = 0;
+        $curly = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = 0; $index < $length - 1; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+
+                continue;
+            }
+
+            match ($character) {
+                '(' => $round++,
+                ')' => $round--,
+                '[' => $square++,
+                ']' => $square--,
+                '{' => $curly++,
+                '}' => $curly--,
+                default => null,
+            };
+
+            if ($character === '?'
+                && $source[$index + 1] === '?'
+                && $round === 0
+                && $square === 0
+                && $curly === 0) {
+                $parts[] = substr($source, $start, $index - $start);
+                $start = $index + 2;
+                $index++;
+            }
+        }
+
+        if ($parts === []) {
+            return null;
+        }
+
+        $parts[] = substr($source, $start);
+
+        return $parts;
+    }
+
+    /** @return array<int, string>|null */
+    private static function matchResults(string $expression): ?array
+    {
+        if (! preg_match('/\Amatch\s*\(/', $expression, $match)) {
+            return null;
+        }
+
+        $open = strlen($match[0]) - 1;
+        $condition = self::parenthesized($expression, $open);
+
+        if ($condition === null) {
+            return null;
+        }
+
+        $brace = $condition[1] + 1;
+
+        while (isset($expression[$brace]) && ctype_space($expression[$brace])) {
+            $brace++;
+        }
+
+        if (($expression[$brace] ?? null) !== '{'
+            || ($body = self::braced($expression, $brace)) === null
+            || trim(substr($expression, $body[1] + 1)) !== '') {
+            return null;
+        }
+
+        $results = [];
+
+        foreach (self::splitTopLevel($body[0], ',') as $arm) {
+            if (($arrow = self::topLevelArrow($arm)) !== null) {
+                $results[] = substr($arm, $arrow + 2);
+            }
+        }
+
+        return $results;
+    }
+
+    /** @return array{string, int}|null */
+    private static function braced(string $source, int $open): ?array
+    {
+        $depth = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = $open; $index < $length; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+            } elseif ($character === '{') {
+                $depth++;
+            } elseif ($character === '}' && --$depth === 0) {
+                return [substr($source, $open + 1, $index - $open - 1), $index];
+            }
+        }
+
+        return null;
     }
 
     /** @return array{int, int}|null */
@@ -424,23 +662,12 @@ class ClassCandidateExtractor
     private static function literals(string $expression): array
     {
         $literals = [];
-        $depth = 0;
         $length = strlen($expression);
 
+        // Nested literals are intentionally included. False positives only add
+        // CSS, while skipping a nested candidate can leave a component unstyled.
         for ($index = 0; $index < $length; $index++) {
             $character = $expression[$index];
-
-            if ($character === '(') {
-                $depth++;
-
-                continue;
-            }
-
-            if ($character === ')') {
-                $depth--;
-
-                continue;
-            }
 
             if ($character !== '\'' && $character !== '"') {
                 continue;
@@ -465,11 +692,9 @@ class ClassCandidateExtractor
                 }
             }
 
-            if ($depth === 0) {
-                $literals[] = $quote === '\''
-                    ? str_replace(['\\\\', "\\'"], ['\\', "'"], $literal)
-                    : stripcslashes($literal);
-            }
+            $literals[] = $quote === '\''
+                ? str_replace(['\\\\', "\\'"], ['\\', "'"], $literal)
+                : stripcslashes($literal);
         }
 
         return $literals;

--- a/src/Support/ClassSourceRegistry.php
+++ b/src/Support/ClassSourceRegistry.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mary\Support;
+
+class ClassSourceRegistry
+{
+    /** @var array<int, string> */
+    protected array $paths = [];
+
+    /** @param  array<int, string>  $paths */
+    public function __construct(array $paths = [])
+    {
+        $this->add($paths);
+    }
+
+    /** @param  string|array<int, string>  $paths */
+    public function add(string|array $paths): static
+    {
+        foreach ((array) $paths as $path) {
+            if ($path !== '' && ! in_array($path, $this->paths, true)) {
+                $this->paths[] = $path;
+            }
+        }
+
+        return $this;
+    }
+
+    /** @return array<int, string> */
+    public function all(): array
+    {
+        return $this->paths;
+    }
+}

--- a/src/Support/DynamicClassCandidateResolver.php
+++ b/src/Support/DynamicClassCandidateResolver.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Mary\Support;
+
+use RuntimeException;
+
+class DynamicClassCandidateResolver
+{
+    private const INTERPOLATION_PATTERN = '/\{\$(?:this->)?(?<callable>[A-Za-z_][A-Za-z0-9_]*)\([^{}]*\)\}|\{\$(?<braced>[A-Za-z_][A-Za-z0-9_]*)\}|\$(?<variable>[A-Za-z_][A-Za-z0-9_]*)/';
+
+    /** @return array<int, string> */
+    public static function expand(string $literal, string $source, string $file): array
+    {
+        $expanded = [$literal];
+
+        while (true) {
+            $resolved = [];
+            $found = false;
+
+            foreach ($expanded as $candidate) {
+                if (! preg_match(self::INTERPOLATION_PATTERN, $candidate, $match)) {
+                    $resolved[] = $candidate;
+
+                    continue;
+                }
+
+                $found = true;
+                $name = $match['callable'] ?: ($match['braced'] ?: $match['variable']);
+                $values = $match['callable']
+                    ? self::methodReturnValues($source, $name)
+                    : self::variableValues($source, $name);
+
+                if ($values === []) {
+                    throw new RuntimeException("Unable to resolve dynamic Mary class [{$match[0]}] in [{$file}].");
+                }
+
+                foreach ($values as $value) {
+                    $resolved[] = str_replace($match[0], $value, $candidate);
+                }
+            }
+
+            $expanded = array_values(array_unique($resolved));
+
+            if (! $found) {
+                return $expanded;
+            }
+        }
+    }
+
+    /** @return array<int, string> */
+    private static function variableValues(string $source, string $name): array
+    {
+        preg_match_all(
+            '/(?:\$this->'.preg_quote($name, '/').'|\$'.preg_quote($name, '/').')\s*=(?!=|>)/',
+            $source,
+            $matches,
+            PREG_OFFSET_CAPTURE
+        );
+
+        $values = [];
+
+        foreach ($matches[0] as [$assignment, $offset]) {
+            $expression = self::terminated($source, $offset + strlen($assignment));
+            array_push($values, ...self::quotedLiterals($expression));
+        }
+
+        return self::unique($values);
+    }
+
+    /** @return array<int, string> */
+    private static function methodReturnValues(string $source, string $name): array
+    {
+        if (! preg_match('/function\s+'.preg_quote($name, '/').'\s*\(/', $source, $match, PREG_OFFSET_CAPTURE)) {
+            return [];
+        }
+
+        $method = $match[0][1];
+        $open = strpos($source, '{', $method + strlen($match[0][0]));
+
+        if ($open === false || ($body = self::braced($source, $open)) === null) {
+            return [];
+        }
+
+        preg_match_all(
+            '/(?:return|=>)\s*(?:\'((?:\\\\.|[^\'\\\\])*)\'|"((?:\\\\.|[^"\\\\])*)")/s',
+            $body,
+            $returns,
+            PREG_SET_ORDER
+        );
+
+        $values = [];
+
+        foreach ($returns as $return) {
+            $singleQuoted = $return[1] ?? '';
+            $values[] = $singleQuoted !== ''
+                ? str_replace(['\\\\', "\\'"], ['\\', "'"], $singleQuoted)
+                : stripcslashes($return[2]);
+        }
+
+        return self::unique($values);
+    }
+
+    private static function terminated(string $source, int $start): string
+    {
+        $round = 0;
+        $square = 0;
+        $curly = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = $start; $index < $length; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+
+                continue;
+            }
+
+            match ($character) {
+                '(' => $round++,
+                ')' => $round--,
+                '[' => $square++,
+                ']' => $square--,
+                '{' => $curly++,
+                '}' => $curly--,
+                default => null,
+            };
+
+            if ($character === ';' && $round === 0 && $square === 0 && $curly === 0) {
+                return substr($source, $start, $index - $start);
+            }
+        }
+
+        return substr($source, $start);
+    }
+
+    private static function braced(string $source, int $open): ?string
+    {
+        $depth = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($source);
+
+        for ($index = $open; $index < $length; $index++) {
+            $character = $source[$index];
+
+            if ($quote !== null) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+
+            if ($character === '\'' || $character === '"') {
+                $quote = $character;
+            } elseif ($character === '{') {
+                $depth++;
+            } elseif ($character === '}' && --$depth === 0) {
+                return substr($source, $open + 1, $index - $open - 1);
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array<int, string> */
+    private static function quotedLiterals(string $source): array
+    {
+        preg_match_all(
+            '/(?:\'((?:\\\\.|[^\'\\\\])*)\'|"((?:\\\\.|[^"\\\\])*)")/s',
+            $source,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        $literals = [];
+
+        foreach ($matches as $match) {
+            $singleQuoted = $match[1] ?? '';
+            $literals[] = $singleQuoted !== ''
+                ? str_replace(['\\\\', "\\'"], ['\\', "'"], $singleQuoted)
+                : stripcslashes($match[2]);
+        }
+
+        return $literals;
+    }
+
+    /** @param  array<int, string>  $values */
+    private static function unique(array $values): array
+    {
+        $values = array_values(array_unique(array_filter($values, fn (string $value): bool => $value !== '')));
+        sort($values);
+
+        return $values;
+    }
+}

--- a/src/Support/DynamicClassCandidateResolver.php
+++ b/src/Support/DynamicClassCandidateResolver.php
@@ -6,50 +6,71 @@ use RuntimeException;
 
 class DynamicClassCandidateResolver
 {
-    private const INTERPOLATION_PATTERN = '/\{\$(?:this->)?(?<callable>[A-Za-z_][A-Za-z0-9_]*)\([^{}]*\)\}|\{\$(?<braced>[A-Za-z_][A-Za-z0-9_]*)\}|\$(?<variable>[A-Za-z_][A-Za-z0-9_]*)/';
+    private const INTERPOLATION_PATTERN = '/\{\$(?:this->)?(?<callable>[A-Za-z_][A-Za-z0-9_]*)\([^{}]*\)\}|\{\$(?:this->)?(?<braced>[A-Za-z_][A-Za-z0-9_]*)\}|\$(?:this->(?<property>[A-Za-z_][A-Za-z0-9_]*)|(?<variable>[A-Za-z_][A-Za-z0-9_]*))/';
 
     /** @return array<int, string> */
     public static function expand(string $literal, string $source, string $file): array
     {
-        $expanded = [$literal];
+        return self::expandCandidate($literal, $source, $file);
+    }
 
-        while (true) {
-            $resolved = [];
-            $found = false;
+    /**
+     * Expand one candidate while keeping dependency ancestry scoped to the
+     * replacement value. Independent references in the same class string do
+     * not inherit each other's ancestry.
+     *
+     * @param  array<int, string>  $references
+     * @return array<int, string>
+     */
+    private static function expandCandidate(string $candidate, string $source, string $file, array $references = []): array
+    {
+        if (! preg_match(self::INTERPOLATION_PATTERN, $candidate, $match)) {
+            return [$candidate];
+        }
 
-            foreach ($expanded as $candidate) {
-                if (! preg_match(self::INTERPOLATION_PATTERN, $candidate, $match)) {
-                    $resolved[] = $candidate;
+        $name = $match['callable'] ?: ($match['braced'] ?: ($match['property'] ?: $match['variable']));
+        $reference = ($match['callable'] ? 'method:' : 'variable:').$name;
 
-                    continue;
-                }
+        if (in_array($reference, $references, true)) {
+            throw new RuntimeException("Cyclic dynamic Mary class reference [{$match[0]}] in [{$file}].");
+        }
 
-                $found = true;
-                $name = $match['callable'] ?: ($match['braced'] ?: $match['variable']);
-                $values = $match['callable']
-                    ? self::methodReturnValues($source, $name)
-                    : self::variableValues($source, $name);
+        $values = $match['callable']
+            ? self::methodReturnValues($source, $name)
+            : self::variableValues($source, $name);
 
-                if ($values === []) {
-                    throw new RuntimeException("Unable to resolve dynamic Mary class [{$match[0]}] in [{$file}].");
-                }
+        if ($values === []) {
+            throw new RuntimeException("Unable to resolve dynamic Mary class [{$match[0]}] in [{$file}].");
+        }
 
-                foreach ($values as $value) {
-                    $resolved[] = str_replace($match[0], $value, $candidate);
-                }
-            }
+        $resolved = [];
 
-            $expanded = array_values(array_unique($resolved));
-
-            if (! $found) {
-                return $expanded;
+        foreach ($values as $value) {
+            foreach (self::expandCandidate($value, $source, $file, [...$references, $reference]) as $expandedValue) {
+                $next = preg_replace_callback(
+                    '/'.preg_quote($match[0], '/').'/',
+                    fn (): string => $expandedValue,
+                    $candidate,
+                    1
+                ) ?? $candidate;
+                array_push($resolved, ...self::expandCandidate($next, $source, $file, $references));
             }
         }
+
+        return array_values(array_unique($resolved));
     }
 
     /** @return array<int, string> */
-    private static function variableValues(string $source, string $name): array
+    private static function variableValues(string $source, string $name, array $seen = []): array
     {
+        $key = 'variable:'.$name;
+
+        if (in_array($key, $seen, true)) {
+            return [];
+        }
+
+        $seen[] = $key;
+
         preg_match_all(
             '/(?:\$this->'.preg_quote($name, '/').'|\$'.preg_quote($name, '/').')\s*=(?!=|>)/',
             $source,
@@ -60,16 +81,25 @@ class DynamicClassCandidateResolver
         $values = [];
 
         foreach ($matches[0] as [$assignment, $offset]) {
-            $expression = self::terminated($source, $offset + strlen($assignment));
+            $expression = self::assignedExpression($source, $offset + strlen($assignment));
             array_push($values, ...self::quotedLiterals($expression));
+            array_push($values, ...self::referencedValues($expression, $source, $seen));
         }
 
         return self::unique($values);
     }
 
     /** @return array<int, string> */
-    private static function methodReturnValues(string $source, string $name): array
+    private static function methodReturnValues(string $source, string $name, array $seen = []): array
     {
+        $key = 'method:'.$name;
+
+        if (in_array($key, $seen, true)) {
+            return [];
+        }
+
+        $seen[] = $key;
+
         if (! preg_match('/function\s+'.preg_quote($name, '/').'\s*\(/', $source, $match, PREG_OFFSET_CAPTURE)) {
             return [];
         }
@@ -81,26 +111,56 @@ class DynamicClassCandidateResolver
             return [];
         }
 
-        preg_match_all(
-            '/(?:return|=>)\s*(?:\'((?:\\\\.|[^\'\\\\])*)\'|"((?:\\\\.|[^"\\\\])*)")/s',
-            $body,
-            $returns,
-            PREG_SET_ORDER
-        );
+        // Keep a conservative superset: any literal in a referenced method may
+        // participate in its returned class expression.
+        $values = self::quotedLiterals($body);
 
+        array_push($values, ...self::referencedValues($body, $source, $seen));
+
+        return self::unique($values);
+    }
+
+    /** @return array<int, string> */
+    private static function referencedValues(string $expression, string $source, array $seen): array
+    {
         $values = [];
 
-        foreach ($returns as $return) {
-            $singleQuoted = $return[1] ?? '';
-            $values[] = $singleQuoted !== ''
-                ? str_replace(['\\\\', "\\'"], ['\\', "'"], $singleQuoted)
-                : stripcslashes($return[2]);
+        preg_match_all(
+            '/\$this->(?<method>[A-Za-z_][A-Za-z0-9_]*)\s*\(/',
+            $expression,
+            $methods
+        );
+
+        foreach ($methods['method'] as $method) {
+            array_push($values, ...self::methodReturnValues($source, $method, $seen));
+        }
+
+        preg_match_all(
+            '/\$this->(?<property>[A-Za-z_][A-Za-z0-9_]*)\b(?!\s*\()/',
+            $expression,
+            $properties
+        );
+
+        foreach ($properties['property'] as $property) {
+            array_push($values, ...self::variableValues($source, $property, $seen));
+        }
+
+        preg_match_all(
+            '/(?<!->)\$(?<variable>[A-Za-z_][A-Za-z0-9_]*)\b(?!\s*->)(?!\s*\()/',
+            $expression,
+            $variables
+        );
+
+        foreach ($variables['variable'] as $variable) {
+            if ($variable !== 'this') {
+                array_push($values, ...self::variableValues($source, $variable, $seen));
+            }
         }
 
         return self::unique($values);
     }
 
-    private static function terminated(string $source, int $start): string
+    private static function assignedExpression(string $source, int $start): string
     {
         $round = 0;
         $square = 0;
@@ -130,6 +190,13 @@ class DynamicClassCandidateResolver
                 continue;
             }
 
+            if (($character === ';' || $character === ',' || $character === ')')
+                && $round === 0
+                && $square === 0
+                && $curly === 0) {
+                return substr($source, $start, $index - $start);
+            }
+
             match ($character) {
                 '(' => $round++,
                 ')' => $round--,
@@ -139,10 +206,6 @@ class DynamicClassCandidateResolver
                 '}' => $curly--,
                 default => null,
             };
-
-            if ($character === ';' && $round === 0 && $square === 0 && $curly === 0) {
-                return substr($source, $start, $index - $start);
-            }
         }
 
         return substr($source, $start);

--- a/src/Traits/Toast.php
+++ b/src/Traits/Toast.php
@@ -2,7 +2,8 @@
 
 namespace Mary\Traits;
 
-use Blade;
+use Illuminate\Support\Facades\Blade;
+use Mary\Facades\Mary;
 
 trait Toast
 {
@@ -12,19 +13,27 @@ trait Toast
         ?string $description = null,
         ?string $position = null,
         string $icon = 'o-information-circle',
-        string $css = 'alert-info',
+        ?string $css = null,
         int $timeout = 3000,
         ?string $redirectTo = null,
         bool $noProgress = false,
         ?string $progressClass = null,
     ) {
+        $defaultCss = match ($type) {
+            'success' => Mary::classes('alert-success'),
+            'warning' => Mary::classes('alert-warning'),
+            'error' => Mary::classes('alert-error'),
+            default => Mary::classes('alert-info'),
+        };
+        $iconClasses = Mary::classes('w-7 h-7');
+
         $toast = [
             'type' => $type,
             'title' => $title,
             'description' => $description,
             'position' => $position,
-            'icon' => Blade::render("<x-mary-icon class='w-7 h-7' name='".$icon."' />"),
-            'css' => $css,
+            'icon' => Blade::render("<x-mary-icon class='{$iconClasses}' name='".$icon."' />"),
+            'css' => $css ?? (string) $defaultCss,
             'timeout' => $timeout,
             'noProgress' => $noProgress,
             'progressClass' => $progressClass,
@@ -45,7 +54,7 @@ trait Toast
         ?string $description = null,
         ?string $position = null,
         string $icon = 'o-check-circle',
-        string $css = 'alert-success',
+        ?string $css = null,
         int $timeout = 3000,
         ?string $redirectTo = null,
         bool $noProgress = false,
@@ -59,7 +68,7 @@ trait Toast
         ?string $description = null,
         ?string $position = null,
         string $icon = 'o-exclamation-triangle',
-        string $css = 'alert-warning',
+        ?string $css = null,
         int $timeout = 3000,
         ?string $redirectTo = null,
         bool $noProgress = false,
@@ -73,7 +82,7 @@ trait Toast
         ?string $description = null,
         ?string $position = null,
         string $icon = 'o-x-circle',
-        string $css = 'alert-error',
+        ?string $css = null,
         int $timeout = 3000,
         ?string $redirectTo = null,
         bool $noProgress = false,
@@ -87,7 +96,7 @@ trait Toast
         ?string $description = null,
         ?string $position = null,
         string $icon = 'o-information-circle',
-        string $css = 'alert-info',
+        ?string $css = null,
         int $timeout = 3000,
         ?string $redirectTo = null,
         bool $noProgress = false,

--- a/src/View/Components/Accordion.php
+++ b/src/View/Components/Accordion.php
@@ -14,7 +14,7 @@ class Accordion extends Component
         public ?string $id = null,
         public ?bool $noJoin = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -22,7 +22,7 @@ class Accordion extends Component
         return <<<'BLADE'
                 <div
                     x-data="{ model: @entangle($attributes->wire('model')) }"
-                    {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => ($noJoin ? '' : 'join join-vertical w-full')]) }}
+                    {{ $attributes->whereDoesntStartWith('wire:model')->class(Mary::classes(['join join-vertical w-full' => ! $noJoin])) }}
                     wire:key="accordion-{{ $uuid }}"
                 >
                         {{ $slot }}

--- a/src/View/Components/Alert.php
+++ b/src/View/Components/Alert.php
@@ -29,7 +29,7 @@ class Alert extends Component
         // Slots
         public mixed $actions = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -38,28 +38,28 @@ class Alert extends Component
                 <div
                     wire:key="{{ $uuid }}"
                     {{ $attributes->whereDoesntStartWith('class') }}
-                    {{ $attributes->class(['alert rounded-md', 'shadow-md' => $shadow])}}
+                    {{ $attributes->maryClass(['alert rounded-md', 'shadow-md' => $shadow])}}
                     x-data="{ show: true }" x-show="show"
                 >
                     @if($icon)
-                        <x-mary-icon :name="$icon" class="self-center" />
+                        <x-mary-icon :name="$icon" class="{{ Mary::classes('self-center') }}" />
                     @endif
 
                     @if($title)
                         <div>
-                            <div @class(["font-bold" => $description])>{{ $title }}</div>
-                            <div class="text-xs">{{ $description }}</div>
+                            <div @maryClass(["font-bold" => $description])>{{ $title }}</div>
+                            <div class="{{ Mary::classes('text-xs') }}">{{ $description }}</div>
                         </div>
                     @else
                         <span>{{ $slot }}</span>
                     @endif
 
-                    <div class="flex items-center gap-3">
+                    <div class="{{ Mary::classes('flex items-center gap-3') }}">
                         {{ $actions }}
                     </div>
 
                     @if($dismissible)
-                        <x-mary-button icon="o-x-mark" @click="show = false" class="btn-xs btn-circle btn-ghost static self-start end-0" />
+                        <x-mary-button icon="o-x-mark" @click="show = false" class="{{ Mary::classes('btn-xs btn-circle btn-ghost static self-start end-0') }}" />
                     @endif
                 </div>
             BLADE;

--- a/src/View/Components/Avatar.php
+++ b/src/View/Components/Avatar.php
@@ -31,17 +31,17 @@ class Avatar extends Component
         public ?string $subtitle = null
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
-            <div class="flex items-center gap-3">
-                <div class="avatar @if(empty($image)) avatar-placeholder @endif">
-                    <div {{ $attributes->class(["w-7 rounded-full", "bg-neutral text-neutral-content" => empty($image)]) }}>
+            <div class="{{ Mary::classes('flex items-center gap-3') }}">
+                <div class="{{ Mary::classes(['avatar', 'avatar-placeholder' => empty($image)]) }}">
+                    <div {{ $attributes->maryClass(["w-7 rounded-full", "bg-neutral text-neutral-content" => empty($image)]) }}>
                         @if(empty($image))
-                            <span class="text-xs" alt="{{ $alt }}">{{ $placeholder }}</span>
+                            <span class="{{ Mary::classes('text-xs') }}" alt="{{ $alt }}">{{ $placeholder }}</span>
                         @else
                             <img src="{{ $image }}" alt="{{ $alt }}" @if($fallbackImage) onerror="this.src='{{ $fallbackImage }}'" @endif />
                         @endif
@@ -50,12 +50,12 @@ class Avatar extends Component
                 @if($title || $subtitle)
                 <div>
                     @if($title)
-                        <div @class(["font-semibold font-lg", is_string($title) ? '' : $title?->attributes->get('class') ]) >
+                        <div class="{{ Mary::classes('font-semibold font-lg')->addRaw(is_string($title) ? '' : $title?->attributes->get('class')) }}" >
                             {{ $title }}
                         </div>
                     @endif
                     @if($subtitle)
-                        <div @class(["text-sm text-base-content/50", is_string($subtitle) ? '' : $subtitle?->attributes->get('class') ]) >
+                        <div class="{{ Mary::classes('text-sm text-base-content/50')->addRaw(is_string($subtitle) ? '' : $subtitle?->attributes->get('class')) }}" >
                             {{ $subtitle }}
                         </div>
                     @endif

--- a/src/View/Components/Badge.php
+++ b/src/View/Components/Badge.php
@@ -17,16 +17,16 @@ class Badge extends Component
         public ?string $iconRight = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div {{ $attributes->class(["badge"])}}>
+                <div {{ $attributes->maryClass(["badge"])}}>
                     <!-- ICON -->
                     @if($icon)
-                        <x-mary-icon :name="$icon" class="h-4 w-4" />
+                        <x-mary-icon :name="$icon" class="{{ Mary::classes('h-4 w-4') }}" />
                     @endif
 
                     <!-- VALUE / SLOT -->
@@ -34,7 +34,7 @@ class Badge extends Component
                     
                     <!-- ICON RIGHT -->
                     @if($iconRight)
-                        <x-mary-icon :name="$iconRight" class="h-4 w-4" />
+                        <x-mary-icon :name="$iconRight" class="{{ Mary::classes('h-4 w-4') }}" />
                     @endif
                 </div>
             HTML;

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -23,13 +23,13 @@ class Breadcrumbs extends Component
         public ?string $id = null,
         public array $items = [],
         public string $separator = 'o-chevron-right',
-        public ?string $linkItemClass = "hover:underline text-sm",
-        public ?string $textItemClass = "text-sm",
-        public ?string $iconClass = "h-4 w-4",
-        public ?string $separatorClass = "h-3 w-3 mx-1 text-base-content/40",
+        public ?string $linkItemClass = null,
+        public ?string $textItemClass = null,
+        public ?string $iconClass = null,
+        public ?string $separatorClass = null,
         public ?bool $noWireNavigate = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function tooltip(array $element): ?string
@@ -50,12 +50,12 @@ class Breadcrumbs extends Component
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
-                <ul {{ $attributes->merge(['class' => 'flex items-center']) }} wire:key="{{ $uuid }}">
+                <ul {{ $attributes->class(Mary::classes('flex items-center')) }} wire:key="{{ $uuid }}">
                     @foreach($items as $element)
 
                         {{-- Tooltip --}}
                         <li
-                            @class(["lg:tooltip {$tooltipPosition($element)}" => $tooltip($element), "hidden sm:block" => !$loop->first && !$loop->last])
+                            @maryClass(["lg:tooltip {$tooltipPosition($element)}" => $tooltip($element), "hidden sm:block" => !$loop->first && !$loop->last])
 
                             @if($tooltip($element))
                                 data-tip="{{ $tooltip($element) }}"
@@ -63,14 +63,14 @@ class Breadcrumbs extends Component
                         >
 
                             @if ($element['link'] ?? null)
-                                <a href="{{ $element['link'] }}" @if(!$noWireNavigate) wire:navigate @endif @class([$linkItemClass])>
+                                <a href="{{ $element['link'] }}" @if(!$noWireNavigate) wire:navigate @endif class="{{ is_null($linkItemClass) ? Mary::classes('hover:underline text-sm') : Mary::classes()->addRaw($linkItemClass) }}">
                             @else
-                                <span @class([$textItemClass])>
+                                <span class="{{ is_null($textItemClass) ? Mary::classes('text-sm') : Mary::classes()->addRaw($textItemClass) }}">
                             @endif
 
                                 {{-- Icon --}}
                                 @if($element['icon'] ?? null)
-                                    <x-mary-icon :name="$element['icon']" @class(["mb-0.5", $iconClass]) />
+                                    <x-mary-icon :name="$element['icon']" class="{{ Mary::classes('mb-0.5')->add(is_null($iconClass) ? 'h-4 w-4' : null)->addRaw($iconClass) }}" />
                                 @endif
 
                                 {{-- Text --}}
@@ -86,17 +86,17 @@ class Breadcrumbs extends Component
                         </li>
 
                         @if($loop->remaining == 1 && $loop->count > 2)
-                            <span class="sm:hidden">...</span>
+                            <span class="{{ Mary::classes('sm:hidden') }}">...</span>
                         @endif
 
                         {{-- Separator --}}
-                        <span @class([
+                        <span @maryClass([
                                 "hidden",
                                 "!block" => ($loop->first || $loop->remaining == 1) && $loop->count > 1,
                                 "sm:!block" => !$loop->last && $loop->count > 1
                              ])
                         >
-                            <x-mary-icon :name="$separator" @class([$separatorClass]) />
+                            <x-mary-icon :name="$separator" class="{{ is_null($separatorClass) ? Mary::classes('h-3 w-3 mx-1 text-base-content/40') : Mary::classes()->addRaw($separatorClass) }}" />
                         </span>
                     @endforeach
                 </ul>

--- a/src/View/Components/Button.php
+++ b/src/View/Components/Button.php
@@ -29,7 +29,7 @@ class Button extends Component
         public ?string $tooltipRight = null,
         public ?string $tooltipBottom = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
         $this->tooltip = $this->tooltip ?? $this->tooltipLeft ?? $this->tooltipRight ?? $this->tooltipBottom;
         $this->tooltipPosition = $this->tooltipLeft ? 'lg:tooltip-left' : ($this->tooltipRight ? 'lg:tooltip-right' : ($this->tooltipBottom ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }
@@ -54,7 +54,7 @@ class Button extends Component
 
                     wire:key="{{ $uuid }}"
                     {{ $attributes->whereDoesntStartWith('class')->merge(['type' => 'button']) }}
-                    {{ $attributes->class(['btn', "!inline-flex lg:tooltip $tooltipPosition" => $tooltip]) }}
+                    {{ $attributes->maryClass(['btn', "!inline-flex lg:tooltip $tooltipPosition" => $tooltip]) }}
 
                     @if($link && $external)
                         target="_blank"
@@ -76,23 +76,23 @@ class Button extends Component
 
                     <!-- SPINNER LEFT -->
                     @if($spinner && !$iconRight)
-                        <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
+                        <span wire:loading wire:target="{{ $spinnerTarget() }}" class="{{ Mary::classes('loading loading-spinner w-5 h-5') }}"></span>
                     @endif
 
                     <!-- ICON -->
                     @if($icon)
-                        <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
+                        <span class="{{ Mary::classes('block') }}" @if($spinner) wire:loading.class="{{ Mary::classes('hidden') }}" wire:target="{{ $spinnerTarget() }}" @endif>
                             <x-mary-icon :name="$icon" />
                         </span>
                     @endif
 
                     <!-- LABEL / SLOT -->
                     @if($label)
-                        <span @class(["hidden lg:block" => $responsive ])>
+                        <span @maryClass(["hidden lg:block" => $responsive ])>
                             {{ $label }}
                         </span>
                         @if(strlen($badge ?? '') > 0)
-                            <span class="badge badge-sm {{ $badgeClasses }}">{{ $badge }}</span>
+                            <span class="{{ Mary::classes('badge badge-sm')->addRaw($badgeClasses) }}">{{ $badge }}</span>
                         @endif
                     @else
                         {{ $slot }}
@@ -100,14 +100,14 @@ class Button extends Component
 
                     <!-- ICON RIGHT -->
                     @if($iconRight)
-                        <span class="block" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
+                        <span class="{{ Mary::classes('block') }}" @if($spinner) wire:loading.class="{{ Mary::classes('hidden') }}" wire:target="{{ $spinnerTarget() }}" @endif>
                             <x-mary-icon :name="$iconRight" />
                         </span>
                     @endif
 
                     <!-- SPINNER RIGHT -->
                     @if($spinner && $iconRight)
-                        <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner w-5 h-5"></span>
+                        <span wire:loading wire:target="{{ $spinnerTarget() }}" class="{{ Mary::classes('loading loading-spinner w-5 h-5') }}"></span>
                     @endif
 
                 @if(!$link)

--- a/src/View/Components/Calendar.php
+++ b/src/View/Components/Calendar.php
@@ -21,11 +21,17 @@ class Calendar extends Component
         public ?array $config = [],
         public ?array $events = [],
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function setup(): string
     {
+        $styles = $this->config['styles'] ?? [
+            'calendar' => (string) app('mary')->classes()->addRaw('vc')->add('w-fit'),
+            'grid' => (string) app('mary')->classes()->addRaw('vc-grid')->add('justify-center'),
+            'column' => (string) app('mary')->classes()->addRaw('vc-column')->add('!min-w-fit !max-w-fit'),
+        ];
+
         $config = json_encode(array_merge([
             'type' => $this->months == 1 ? 'default' : 'multiple',
             'displayMonthsCount' => $this->months,
@@ -36,11 +42,7 @@ class Calendar extends Component
             'selectedWeekends' => $this->weekendHighlight ? [0, 6] : [],
             'selectionDatesMode' => false,
             'displayDatesOutside' => false,
-            'styles' => [
-                'calendar' => 'vc w-fit',
-                'grid' => 'vc-grid justify-center',
-                'column' => 'vc-column !min-w-fit !max-w-fit',
-            ]
+            'styles' => $styles,
         ], $this->config));
 
         return $config;
@@ -66,14 +68,14 @@ class Calendar extends Component
             }
 
             return collect($dates)->flatMap(function ($date) use ($event, &$buffer) {
-                $html = '<div><strong>' . $event['label'] . '</strong></div><div>' . ($event['description'] ?? null) . '</div><hr class="my-3 last:hidden" />';
+                $html = '<div><strong>'.$event['label'].'</strong></div><div>'.($event['description'] ?? null).'</div><hr class="'.app('mary')->classes('my-3 last:hidden').'" />';
 
-                $buffer[$date] = ($buffer[$date] ?? '') . $html;
+                $buffer[$date] = ($buffer[$date] ?? '').$html;
 
                 return [
                     $date => [
                         'modifier' => $event['css'],
-                        'html' => $buffer[$date]
+                        'html' => $buffer[$date],
                     ],
                 ];
             });

--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -24,7 +24,7 @@ class Card extends Component
         public mixed $figure = null,
         public ?string $bodyClass = 'null'
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function progressTarget(): ?string
@@ -43,43 +43,43 @@ class Card extends Component
                     {{
                         $attributes
                             ->merge(['wire:key' => $uuid ])
-                            ->class(['card bg-base-100 p-5', 'shadow-xs' => $shadow])
+                            ->maryClass(['card bg-base-100 p-5', 'shadow-xs' => $shadow])
                     }}
                 >
                     @if($figure)
-                        <figure {{ $figure->attributes->class(["mb-5 -m-5"]) }}>
+                        <figure {{ $figure->attributes->maryClass(["mb-5 -m-5"]) }}>
                             {{ $figure }}
                         </figure>
                     @endif
 
                     @if($title || $subtitle)
-                        <div class="pb-5">
-                            <div class="flex gap-3 justify-between items-center w-full">
-                                <div class="grow-1">
+                        <div class="{{ Mary::classes('pb-5') }}">
+                            <div class="{{ Mary::classes('flex gap-3 justify-between items-center w-full') }}">
+                                <div class="{{ Mary::classes('grow-1') }}">
                                     @if($title)
-                                        <div @class(["text-xl font-bold", is_string($title) ? '' : $title?->attributes->get('class') ]) >
+                                        <div class="{{ Mary::classes('text-xl font-bold')->addRaw(is_string($title) ? '' : $title?->attributes->get('class')) }}" >
                                             {{ $title }}
                                         </div>
                                     @endif
                                     @if($subtitle)
-                                    <div @class(["text-base-content/50 text-sm mt-1", is_string($subtitle) ? '' : $subtitle?->attributes->get('class') ]) >
+                                    <div class="{{ Mary::classes('text-base-content/50 text-sm mt-1')->addRaw(is_string($subtitle) ? '' : $subtitle?->attributes->get('class')) }}" >
                                             {{ $subtitle }}
                                         </div>
                                     @endif
                                 </div>
 
                                 @if($menu)
-                                    <div {{ $menu->attributes->class(["flex items-center gap-2"]) }}> {{ $menu }} </div>
+                                    <div {{ $menu->attributes->maryClass(["flex items-center gap-2"]) }}> {{ $menu }} </div>
                                 @endif
                             </div>
 
                             @if($separator)
-                                <hr class="mt-3 border-t-[length:var(--border)] border-base-content/10" />
+                                <hr class="{{ Mary::classes('mt-3 border-t-[length:var(--border)] border-base-content/10') }}" />
 
                                 @if($progressIndicator)
-                                    <div class="h-0.5 -mt-4 mb-4">
+                                    <div class="{{ Mary::classes('h-0.5 -mt-4 mb-4') }}">
                                         <progress
-                                            class="progress progress-primary w-full h-0.5"
+                                            class="{{ Mary::classes('progress progress-primary w-full h-0.5') }}"
                                             wire:loading
 
                                             @if($progressTarget())
@@ -91,18 +91,18 @@ class Card extends Component
                         </div>
                     @endif
 
-                    <div @class([ 'grow-1', $bodyClass ])>
+                    <div class="{{ Mary::classes('grow-1')->addRaw($bodyClass) }}">
                         {{ $slot }}
                     </div>
 
                     @if($actions)
                         @if($separator)
-                            <hr class="mt-5 border-t-[length:var(--border)] border-base-content/10" />
+                            <hr class="{{ Mary::classes('mt-5 border-t-[length:var(--border)] border-base-content/10') }}" />
                         @else
                             <div></div>
                         @endif
 
-                        <div @class(["flex w-full items-end justify-end gap-3 pt-5", is_string($actions) ? '' : $actions?->attributes->get('class') ])>
+                        <div class="{{ Mary::classes('flex w-full items-end justify-end gap-3 pt-5')->addRaw(is_string($actions) ? '' : $actions?->attributes->get('class')) }}">
                             {{ $actions }}
                         </div>
                     @endif

--- a/src/View/Components/Carousel.php
+++ b/src/View/Components/Carousel.php
@@ -25,7 +25,7 @@ class Carousel extends Component
         // Slots
         public mixed $content = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -72,7 +72,7 @@ class Carousel extends Component
                     if (this.autoplay)
                         setInterval(() => { this.next(); }, this.interval);
                 }
-            }" class="relative w-full overflow-hidden">
+            }" class="{{ Mary::classes('relative w-full overflow-hidden') }}">
 
                 @if(!$withoutArrows)
                     <!-- previous button -->
@@ -80,21 +80,21 @@ class Carousel extends Component
                         icon="o-chevron-left"
                         aria-label="Previous image"
                         @click="previous()"
-                        class="absolute cursor-pointer left-5 top-1/2 z-[2] btn-circle btn-sm"
+                        class="{{ Mary::classes('absolute cursor-pointer left-5 top-1/2 z-[2] btn-circle btn-sm') }}"
                     />
                     <!-- next button -->
                     <x-mary-button
                         icon="o-chevron-right"
                         aria-label="Next image"
                         @click="next()"
-                        class="absolute cursor-pointer right-5 top-1/2 z-[2] btn-circle btn-sm"
+                        class="{{ Mary::classes('absolute cursor-pointer right-5 top-1/2 z-[2] btn-circle btn-sm') }}"
                     />
                 @endif
 
                 <!-- slides -->
                 <div
                      @touchstart="handleTouchStart($event)" @touchmove="handleTouchMove($event)" @touchend="handleTouchEnd()"
-                    {{ $attributes->class(["relative h-64 w-full rounded-box overflow-hidden"]) }}
+                    {{ $attributes->maryClass(["relative h-64 w-full rounded-box overflow-hidden"]) }}
                 >
                     <!-- Slot content -->
                     @foreach($slides as $index => $slide)
@@ -102,40 +102,40 @@ class Carousel extends Component
                             x-cloak
                             x-show="currentSlideIndex == {{ $index + 1 }}"
                             x-transition.opacity.duration.500ms
-                            @class(["absolute inset-0", "cursor-pointer" => data_get($slide, 'url') ])
+                            @maryClass(["absolute inset-0", "cursor-pointer" => data_get($slide, 'url') ])
                             @if(data_get($slide, 'url'))
                                 @click="window.location = '{{ data_get($slide, 'url') }}'"
                             @endif
                         >
                             <!-- Custom content -->
                             @if($content)
-                                <div class="absolute inset-0 z-[1]">
+                                <div class="{{ Mary::classes('absolute inset-0 z-[1]') }}">
                                      {{ $content($slide) }}
                                 </div>
                             <!-- Default content -->
                             @else
                                   <div
-                                      @class([
+                                      @maryClass([
                                           "absolute inset-0 z-[1] flex flex-col items-center justify-end gap-2 px-20 py-12 text-center",
                                            "bg-gradient-to-t from-slate-900/85" => data_get($slide, 'urlText') || data_get($slide, 'title') || data_get($slide, 'description')
                                       ])
                                 >
                                     <!-- Title -->
-                                    <h3 class="w-full text-2xl lg:text-3xl font-bold text-white">{{ data_get($slide, 'title') }}</h3>
+                                    <h3 class="{{ Mary::classes('w-full text-2xl lg:text-3xl font-bold text-white') }}">{{ data_get($slide, 'title') }}</h3>
 
                                     <!-- Description -->
-                                    <div class="w-full text-sm text-white mb-5">{{ data_get($slide, 'description') }}</div>
+                                    <div class="{{ Mary::classes('w-full text-sm text-white mb-5') }}">{{ data_get($slide, 'description') }}</div>
 
                                     <!-- Button-->
                                     @if(data_get($slide, 'urlText'))
-                                        <a href="{{ data_get($slide, 'url') }}" class="btn btn-sm btn-outline text-white border-white hover:bg-transparent my-3 hover:scale-105">{{ data_get($slide, 'urlText') }}</a>
+                                        <a href="{{ data_get($slide, 'url') }}" class="{{ Mary::classes('btn btn-sm btn-outline text-white border-white hover:bg-transparent my-3 hover:scale-105') }}">{{ data_get($slide, 'urlText') }}</a>
                                     @endif
                                 </div>
                             @endif
 
                             <!-- Image -->
                             <img
-                                class="w-full h-full inset-0 object-cover"
+                                class="{{ Mary::classes('w-full h-full inset-0 object-cover') }}"
                                 src="{{ data_get($slide, 'image') }}"
                                 alt="{{ data_get($slide, 'alt') }}"
                                 loading="{{ data_get($slide, 'lazy') ? 'lazy' : 'eager' }}"
@@ -146,13 +146,13 @@ class Carousel extends Component
                 </div>
                 <!-- indicators -->
                 @if(! $withoutIndicators)
-                    <div class="absolute rounded-xl bottom-3 md:bottom-5 left-1/2 z-[2] flex -translate-x-1/2 gap-4 md:gap-5 bg-base-300 px-1.5 py-1 md:px-2" role="group" aria-label="slides" >
+                    <div class="{{ Mary::classes('absolute rounded-xl bottom-3 md:bottom-5 left-1/2 z-[2] flex -translate-x-1/2 gap-4 md:gap-5 bg-base-300 px-1.5 py-1 md:px-2') }}" role="group" aria-label="slides" >
                         <template x-for="(slide, index) in slides">
                             <button
-                                class="size-2.5 cursor-pointer rounded-full transition hover:scale-125"
+                                class="{{ Mary::classes('size-2.5 cursor-pointer rounded-full transition hover:scale-125') }}"
                                 :aria-label="'Image ' + (index+1)"
                                 @click="currentSlideIndex = index + 1"
-                                :class="[currentSlideIndex === index + 1 ? 'bg-base-content' : 'bg-base-content/30']">
+                                :class="[currentSlideIndex === index + 1 ? '{{ Mary::classes('bg-base-content') }}' : '{{ Mary::classes('bg-base-content/30') }}']">
                             </button>
                         </template>
                     </div>

--- a/src/View/Components/Chart.php
+++ b/src/View/Components/Chart.php
@@ -13,7 +13,7 @@ class Chart extends Component
     public function __construct(
         public ?string $id = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -28,7 +28,7 @@ class Chart extends Component
                         }
                     }"
 
-                    {{ $attributes->class(["relative"]) }}
+                    {{ $attributes->maryClass(["relative"]) }}
                 >
                     <canvas x-ref="chart"></canvas>
                 </div>

--- a/src/View/Components/Checkbox.php
+++ b/src/View/Components/Checkbox.php
@@ -15,15 +15,15 @@ class Checkbox extends Component
         public ?string $label = null,
         public ?bool $right = false,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -40,9 +40,9 @@ class Checkbox extends Component
     {
         return <<<'BLADE'
             <div>
-                <fieldset class="fieldset">
-                    <div class="w-full">
-                        <label @class(["flex gap-3 items-center cursor-pointer", "justify-between" => $right, "!items-start" => $hint])>
+                <fieldset class="{{ Mary::classes('fieldset') }}">
+                    <div class="{{ Mary::classes('w-full') }}">
+                        <label @maryClass(["flex gap-3 items-center cursor-pointer", "justify-between" => $right, "!items-start" => $hint])>
 
                             {{-- CHECKBOX --}}
                             <input
@@ -50,24 +50,24 @@ class Checkbox extends Component
                                 type="checkbox"
                                 {{
                                     $attributes->whereDoesntStartWith("id")
-                                        ->class(["order-2" => $right])
-                                        ->merge(["class" => "checkbox"])
+                                        ->maryClass(["order-2" => $right])
+                                        ->class(Mary::classes('checkbox'))
                                  }}
                             />
 
                             {{-- LABEL --}}
-                             <div @class(["order-1" => $right])>
-                                <div class="text-sm font-medium">
+                             <div @maryClass(["order-1" => $right])>
+                                <div class="{{ Mary::classes('text-sm font-medium') }}">
                                     {{ $label }}
 
                                     @if($attributes->get('required'))
-                                        <span class="text-error">*</span>
+                                        <span class="{{ Mary::classes('text-error') }}">*</span>
                                     @endif
                                 </div>
 
                                 {{-- HINT --}}
                                 @if($hint)
-                                    <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                                    <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                                 @endif
                             </div>
                         </label>
@@ -77,7 +77,7 @@ class Checkbox extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -16,7 +16,7 @@ class Choices extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?bool $inline = false,
@@ -47,13 +47,13 @@ class Choices extends Component
 
         // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
 
@@ -63,10 +63,10 @@ class Choices extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
 
         if (($this->allowAll || $this->compact) && ($this->single || $this->searchable)) {
-            throw new Exception("`allow-all` and `compact` does not work combined with `single` or `searchable`.");
+            throw new Exception('`allow-all` and `compact` does not work combined with `single` or `searchable`.');
         }
     }
 
@@ -239,21 +239,21 @@ class Choices extends Component
                         @keydown.up="$focus.previous()"
                         @keydown.down="$focus.next()"
                     >
-                        <fieldset class="fieldset py-0">
+                        <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                             {{-- STANDARD LABEL --}}
                             @if($label && !$inline)
-                                <legend class="fieldset-legend mb-0.5">
+                                <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                                     {{ $label }}
 
                                     @if($attributes->get('required'))
-                                        <span class="text-error">*</span>
+                                        <span class="{{ Mary::classes('text-error') }}">*</span>
                                     @endif
 
                                     {{-- INPUT POPOVER --}}
                                     @if($popover)
                                         <x-mary-popover offset="5" position="top-start">
                                             <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                                <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                                <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                             </x-slot:trigger>
                                             <x-slot:content class="{{ $popoverContentClass }}">
                                                 {{ $popover }}
@@ -263,19 +263,19 @@ class Choices extends Component
                                 </legend>
                             @endif
 
-                            <label @class(["floating-label" => $label && $inline])>
+                            <label @maryClass(["floating-label" => $label && $inline])>
                                 {{-- FLOATING LABEL--}}
                                 @if ($label && $inline)
-                                    <span class="font-semibold">
+                                    <span class="{{ Mary::classes('font-semibold') }}">
                                         {{ $label }}
 
                                         @if($attributes->get('required'))
-                                            <span class="text-error">*</span>
+                                            <span class="{{ Mary::classes('text-error') }}">*</span>
                                         @endif
                                     </span>
                                 @endif
 
-                                <div @class(["w-full", "join" => $prepend || $append])>
+                                <div @maryClass(["w-full", "join" => $prepend || $append])>
                                     {{-- PREPEND --}}
                                     @if($prepend)
                                         {{ $prepend }}
@@ -294,7 +294,7 @@ class Choices extends Component
                                         @endif
 
                                         {{
-                                            $attributes->whereStartsWith('class')->class([
+                                            $attributes->whereStartsWith('class')->maryClass([
                                                 "select w-full min-h-[var(--size)] h-auto ps-2.5",
                                                 "join-item" => $prepend || $append,
                                                 "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -304,25 +304,25 @@ class Choices extends Component
                                     >
                                         {{-- PREFIX --}}
                                         @if($prefix)
-                                            <span class="label">{{ $prefix }}</span>
+                                            <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                         @endif
 
                                         {{-- ICON LEFT --}}
                                         @if($icon)
-                                            <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 opacity-40" />
+                                            <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                         @endif
 
-                                        <div class="w-full py-0.5 min-h-3 content-center text-wrap">
+                                        <div class="{{ Mary::classes('w-full py-0.5 min-h-3 content-center text-wrap') }}">
 
                                             {{-- SELECTED OPTIONS --}}
                                             <span wire:key="selected-options-{{ $uuid }}">
                                                 @if($compact)
-                                                    <div class="badge badge-soft">
-                                                        <span class="font-black" x-text="selectedOptions.length"></span> {{ $compactText }}
+                                                    <div class="{{ Mary::classes('badge badge-soft') }}">
+                                                        <span class="{{ Mary::classes('font-black') }}" x-text="selectedOptions.length"></span> {{ $compactText }}
                                                     </div>
                                                 @else
                                                     <template x-for="(option, index) in selectedOptions" :key="index">
-                                                        <span class="mary-choices-element cursor-pointer badge badge-soft m-0.5 !inline-block !h-auto">
+                                                        <span class="{{ Mary::classes('cursor-pointer badge badge-soft m-0.5 !inline-block !h-auto')->addRaw('mary-choices-element') }}">
                                                             {{-- SELECTION SLOT --}}
                                                             @if($selection)
                                                                 <span x-html="document.getElementById('selection-{{ $uuid . '-\' + option.'. $optionValue }}).innerHTML"></span>
@@ -331,7 +331,7 @@ class Choices extends Component
                                                             @endif
 
                                                             @if(!$isDisabled() && !$isReadonly())
-                                                                <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="w-4 h-4 hover:text-error" />
+                                                                <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="{{ Mary::classes('w-4 h-4 hover:text-error') }}" />
                                                             @endif
                                                         </span>
                                                     </template>
@@ -339,7 +339,7 @@ class Choices extends Component
                                             </span>
 
                                             {{-- PLACEHOLDER --}}
-                                            <span :class="(focused || !isSelectionEmpty) && 'hidden'" class="text-base-content/40">
+                                            <span :class="(focused || !isSelectionEmpty) && '{{ Mary::classes('hidden') }}'" class="{{ Mary::classes('text-base-content/40') }}">
                                                 {{ $attributes->get('placeholder') }}
                                             </span>
 
@@ -349,7 +349,7 @@ class Choices extends Component
                                                 @input="focus(); resize();"
                                                 @keydown.arrow-down.prevent="focus()"
                                                 :required="isRequired && isSelectionEmpty"
-                                                class="w-1 !inline-block outline-hidden"
+                                                class="{{ Mary::classes('w-1 !inline-block outline-hidden') }}"
 
                                                 {{ $attributes->whereStartsWith('@') }}
 
@@ -371,17 +371,17 @@ class Choices extends Component
 
                                         {{-- CLEAR ICON  --}}
                                         @if($clearable && !$isReadonly() && !$isDisabled())
-                                            <x-mary-icon @click="reset()" x-show="!isSelectionEmpty" name="o-x-mark" class="cursor-pointer w-4 h-4 opacity-40"/>
+                                            <x-mary-icon @click="reset()" x-show="!isSelectionEmpty" name="o-x-mark" class="{{ Mary::classes('cursor-pointer w-4 h-4 opacity-40') }}"/>
                                         @endif
 
                                         {{-- ICON RIGHT --}}
                                         @if($iconRight)
-                                            <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                            <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                         @endif
 
                                         {{-- SUFFIX --}}
                                         @if($suffix)
-                                            <span class="label">{{ $suffix }}</span>
+                                            <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                         @endif
                                     </label>
 
@@ -396,7 +396,7 @@ class Choices extends Component
                             @if(!$omitError && $errors->has($errorFieldName()))
                                 @foreach($errors->get($errorFieldName()) as $message)
                                     @foreach(Arr::wrap($message) as $line)
-                                        <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                        <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                         @break($firstErrorOnly)
                                     @endforeach
                                     @break($firstErrorOnly)
@@ -405,31 +405,31 @@ class Choices extends Component
 
                             {{-- HINT --}}
                             @if($hint)
-                                <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                                <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                             @endif
                         </fieldset>
 
                         {{-- OPTIONS LIST --}}
-                        <div x-cloak x-show="focused" class="relative" wire:key="options-list-main-{{ $uuid }}">
+                        <div x-cloak x-show="focused" class="{{ Mary::classes('relative') }}" wire:key="options-list-main-{{ $uuid }}">
                             <div
                                 wire:key="options-list-{{ $uuid }}"
-                                class="{{ $height }} w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto"
+                                class="{{ Mary::classes('w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto')->addRaw($height) }}"
                                 x-anchor.bottom-start="$refs.container"
                             >
 
                                 {{-- PROGRESS --}}
                                 @if(!$noProgress)
-                                    <progress wire:loading wire:target="{{ preg_replace('/\((.*?)\)/', '', $searchFunction) }}" class="progress absolute top-0 h-0.5"></progress>
+                                    <progress wire:loading wire:target="{{ preg_replace('/\((.*?)\)/', '', $searchFunction) }}" class="{{ Mary::classes('progress absolute top-0 h-0.5') }}"></progress>
                                 @endif
 
                                {{-- SELECT ALL --}}
                                @if($allowAll)
                                    <div
                                         wire:key="allow-all-{{ rand() }}"
-                                        class="font-bold   border border-s-4 border-s-base-content/10 border-base-200 hover:bg-base-200"
+                                        class="{{ Mary::classes('font-bold   border border-s-4 border-s-base-content/10 border-base-200 hover:bg-base-200') }}"
                                    >
-                                        <div x-show="!isAllSelected" @click="selectAll()" class="p-3 underline decoration-wavy decoration-info">{{ $allowAllText }}</div>
-                                        <div x-show="isAllSelected" @click="reset()" class="p-3 underline decoration-wavy decoration-error">{{ $removeAllText }}</div>
+                                        <div x-show="!isAllSelected" @click="selectAll()" class="{{ Mary::classes('p-3 underline decoration-wavy decoration-info') }}">{{ $allowAllText }}</div>
+                                        <div x-show="isAllSelected" @click="reset()" class="{{ Mary::classes('p-3 underline decoration-wavy decoration-error') }}">{{ $removeAllText }}</div>
                                    </div>
                                @endif
 
@@ -437,7 +437,7 @@ class Choices extends Component
                                 <div
                                     x-show="noResults"
                                     wire:key="no-results-{{ rand() }}"
-                                    class="p-3 decoration-wavy decoration-warning underline font-bold border border-s-4 border-s-warning border-b-base-200"
+                                    class="{{ Mary::classes('p-3 decoration-wavy decoration-warning underline font-bold border border-s-4 border-s-warning border-b-base-200') }}"
                                 >
                                     {{ $noResultText }}
                                 </div>
@@ -447,8 +447,8 @@ class Choices extends Component
                                         wire:key="option-{{ data_get($option, $optionValue) }}"
                                         @click="toggle({{ $getOptionValue($option) }}, true)"
                                         @keydown.enter="toggle({{ $getOptionValue($option) }}, true)"
-                                        :class="isActive({{ $getOptionValue($option) }}) && 'border-s-4 border-s-base-content'"
-                                        class="border-s-4 border-base-content/10 focus:bg-base-200 focus:outline-none"
+                                        :class="isActive({{ $getOptionValue($option) }}) && '{{ Mary::classes('border-s-4 border-s-base-content') }}'"
+                                        class="{{ Mary::classes('border-s-4 border-base-content/10 focus:bg-base-200 focus:outline-none') }}"
                                         tabindex="0"
                                     >
                                         {{-- ITEM SLOT --}}
@@ -460,7 +460,7 @@ class Choices extends Component
 
                                         {{-- SELECTION SLOT --}}
                                         @if($selection)
-                                            <span id="selection-{{ $uuid }}-{{ data_get($option, $optionValue) }}" class="hidden">
+                                            <span id="selection-{{ $uuid }}-{{ data_get($option, $optionValue) }}" class="{{ Mary::classes('hidden') }}">
                                                 {{ $selection($option) }}
                                             </span>
                                         @endif

--- a/src/View/Components/Choices.php
+++ b/src/View/Components/Choices.php
@@ -413,7 +413,9 @@ class Choices extends Component
                         <div x-cloak x-show="focused" class="{{ Mary::classes('relative') }}" wire:key="options-list-main-{{ $uuid }}">
                             <div
                                 wire:key="options-list-{{ $uuid }}"
-                                class="{{ Mary::classes('w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto')->addRaw($height) }}"
+                                class="{{ Mary::classes('w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto')
+                                    ->add($height === 'max-h-64' ? 'max-h-64' : null)
+                                    ->addRaw($height !== 'max-h-64' ? $height : null) }}"
                                 x-anchor.bottom-start="$refs.container"
                             >
 

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -419,7 +419,9 @@ class ChoicesOffline extends Component
                         <div x-cloak x-show="focused" class="{{ Mary::classes('relative') }}" wire:key="options-list-main-{{ $uuid }}" >
                                 <div
                                     wire:key="options-list-{{ $uuid }}"
-                                    class="{{ Mary::classes('w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto')->addRaw($height) }}"
+                                    class="{{ Mary::classes('w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto')
+                                        ->add($height === 'max-h-64' ? 'max-h-64' : null)
+                                        ->addRaw($height !== 'max-h-64' ? $height : null) }}"
                                     x-anchor.bottom-start="$refs.container"
                                 >
 

--- a/src/View/Components/ChoicesOffline.php
+++ b/src/View/Components/ChoicesOffline.php
@@ -16,7 +16,7 @@ class ChoicesOffline extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?bool $inline = false,
@@ -45,13 +45,13 @@ class ChoicesOffline extends Component
 
         // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error label-text-alt p-1',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
 
@@ -61,10 +61,10 @@ class ChoicesOffline extends Component
         public mixed $prepend = null,
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
 
         if (($this->allowAll || $this->compact) && ($this->single || $this->searchable)) {
-            throw new Exception("`allow-all` and `compact` does not work combined with `single` or `searchable`.");
+            throw new Exception('`allow-all` and `compact` does not work combined with `single` or `searchable`.');
         }
     }
 
@@ -206,9 +206,9 @@ class ChoicesOffline extends Component
                             lookup() {
                                 Array.from(this.$refs.choicesOptions.children).forEach(child => {
                                     if (!child.getAttribute('search-value').match(new RegExp(this.search, 'i'))){
-                                        child.classList.add('hidden')
+                                        child.classList.add('{{ Mary::classes('hidden') }}')
                                     } else {
-                                        child.classList.remove('hidden')
+                                        child.classList.remove('{{ Mary::classes('hidden') }}')
                                     }
                                 })
 
@@ -245,21 +245,21 @@ class ChoicesOffline extends Component
                         @keydown.up="focusPrevious()"
                         @keydown.down="focusNext()"
                     >
-                        <fieldset class="fieldset py-0">
+                        <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                             {{-- STANDARD LABEL --}}
                             @if($label && !$inline)
-                                <legend class="fieldset-legend mb-0.5">
+                                <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                                     {{ $label }}
 
                                     @if($attributes->get('required'))
-                                        <span class="text-error">*</span>
+                                        <span class="{{ Mary::classes('text-error') }}">*</span>
                                     @endif
 
                                     {{-- INPUT POPOVER --}}
                                     @if($popover)
                                         <x-mary-popover offset="5" position="top-start">
                                             <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                                <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                                <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                             </x-slot:trigger>
                                             <x-slot:content class="{{ $popoverContentClass }}">
                                                 {{ $popover }}
@@ -269,19 +269,19 @@ class ChoicesOffline extends Component
                                 </legend>
                             @endif
 
-                            <label @class(["floating-label" => $label && $inline])>
+                            <label @maryClass(["floating-label" => $label && $inline])>
                                 {{-- FLOATING LABEL--}}
                                 @if ($label && $inline)
-                                    <span class="font-semibold">
+                                    <span class="{{ Mary::classes('font-semibold') }}">
                                         {{ $label }}
 
                                         @if($attributes->get('required'))
-                                            <span class="text-error">*</span>
+                                            <span class="{{ Mary::classes('text-error') }}">*</span>
                                         @endif
                                     </span>
                                 @endif
 
-                                <div @class(["w-full", "join" => $prepend || $append])>
+                                <div @maryClass(["w-full", "join" => $prepend || $append])>
                                     {{-- PREPEND --}}
                                     @if($prepend)
                                         {{ $prepend }}
@@ -300,7 +300,7 @@ class ChoicesOffline extends Component
                                         @endif
 
                                         {{
-                                            $attributes->whereStartsWith('class')->class([
+                                            $attributes->whereStartsWith('class')->maryClass([
                                                 "select w-full min-h-[var(--size)] h-auto ps-2.5",
                                                 "join-item" => $prepend || $append,
                                                 "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -310,25 +310,25 @@ class ChoicesOffline extends Component
                                     >
                                         {{-- PREFIX --}}
                                         @if($prefix)
-                                            <span class="label">{{ $prefix }}</span>
+                                            <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                         @endif
 
                                         {{-- ICON LEFT --}}
                                         @if($icon)
-                                            <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 opacity-40" />
+                                            <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                         @endif
 
-                                        <div class="w-full py-0.5 min-h-3 content-center text-wrap">
+                                        <div class="{{ Mary::classes('w-full py-0.5 min-h-3 content-center text-wrap') }}">
 
                                             {{-- SELECTED OPTIONS --}}
                                             <span wire:key="selected-options-{{ $uuid }}">
                                                 @if($compact)
-                                                    <div class="badge badge-soft">
-                                                        <span class="font-black" x-text="selectedOptions.length"></span> {{ $compactText }}
+                                                    <div class="{{ Mary::classes('badge badge-soft') }}">
+                                                        <span class="{{ Mary::classes('font-black') }}" x-text="selectedOptions.length"></span> {{ $compactText }}
                                                     </div>
                                                 @else
                                                     <template x-for="(option, index) in selectedOptions" :key="index">
-                                                        <span class="mary-choices-element cursor-pointer badge badge-soft m-0.5 !inline-block !h-auto">
+                                                        <span class="{{ Mary::classes('cursor-pointer badge badge-soft m-0.5 !inline-block !h-auto')->addRaw('mary-choices-element') }}">
                                                             {{-- SELECTION SLOT --}}
                                                             @if($selection)
                                                                 <span x-html="document.getElementById('selection-{{ $uuid . '-\' + option.'. $optionValue }}).innerHTML"></span>
@@ -337,7 +337,7 @@ class ChoicesOffline extends Component
                                                             @endif
 
                                                             @if(!$isDisabled() && !$isReadonly())
-                                                                <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="w-4 h-4 hover:text-error" />
+                                                                <x-mary-icon @click="toggle(option.{{ $optionValue }})" x-show="!isReadonly && !isDisabled && !isSingle" name="o-x-mark" class="{{ Mary::classes('w-4 h-4 hover:text-error') }}" />
                                                             @endif
                                                         </span>
                                                     </template>
@@ -345,7 +345,7 @@ class ChoicesOffline extends Component
                                             </span>
 
                                             {{-- PLACEHOLDER --}}
-                                            <span :class="(focused || !isSelectionEmpty) && 'hidden'" class="text-base-content/40">
+                                            <span :class="(focused || !isSelectionEmpty) && '{{ Mary::classes('hidden') }}'" class="{{ Mary::classes('text-base-content/40') }}">
                                                 {{ $attributes->get('placeholder') }}
                                             </span>
 
@@ -358,7 +358,7 @@ class ChoicesOffline extends Component
                                                 @input="focus(); resize();"
                                                 @keydown.arrow-down.prevent="focus()"
                                                 :required="isRequired && isSelectionEmpty"
-                                                class="w-1 !inline-block outline-hidden"
+                                                class="{{ Mary::classes('w-1 !inline-block outline-hidden') }}"
 
                                                 {{ $attributes->whereStartsWith('@') }}
 
@@ -376,17 +376,17 @@ class ChoicesOffline extends Component
 
                                         {{-- CLEAR ICON  --}}
                                         @if($clearable && !$isReadonly() && !$isDisabled())
-                                            <x-mary-icon @click="reset()" x-show="!isSelectionEmpty" name="o-x-mark" class="cursor-pointer w-4 h-4 opacity-40"/>
+                                            <x-mary-icon @click="reset()" x-show="!isSelectionEmpty" name="o-x-mark" class="{{ Mary::classes('cursor-pointer w-4 h-4 opacity-40') }}"/>
                                         @endif
 
                                         {{-- ICON RIGHT --}}
                                         @if($iconRight)
-                                            <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                            <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                         @endif
 
                                         {{-- SUFFIX --}}
                                         @if($suffix)
-                                            <span class="label">{{ $suffix }}</span>
+                                            <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                         @endif
 
                                     </label>
@@ -402,7 +402,7 @@ class ChoicesOffline extends Component
                                 @if(!$omitError && $errors->has($errorFieldName()))
                                     @foreach($errors->get($errorFieldName()) as $message)
                                         @foreach(Arr::wrap($message) as $line)
-                                            <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                            <div class="{{ is_null($errorClass) ? Mary::classes('text-error label-text-alt p-1') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                             @break($firstErrorOnly)
                                         @endforeach
                                         @break($firstErrorOnly)
@@ -411,15 +411,15 @@ class ChoicesOffline extends Component
 
                                 {{-- HINT --}}
                                 @if($hint)
-                                    <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                                    <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                                 @endif
                         </fieldset>
 
                         {{-- OPTIONS LIST --}}
-                        <div x-cloak x-show="focused" class="relative" wire:key="options-list-main-{{ $uuid }}" >
+                        <div x-cloak x-show="focused" class="{{ Mary::classes('relative') }}" wire:key="options-list-main-{{ $uuid }}" >
                                 <div
                                     wire:key="options-list-{{ $uuid }}"
-                                    class="{{ $height }} w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto"
+                                    class="{{ Mary::classes('w-full absolute z-10 shadow-xl bg-base-100 border border-base-content/10 rounded-lg cursor-pointer overflow-y-auto')->addRaw($height) }}"
                                     x-anchor.bottom-start="$refs.container"
                                 >
 
@@ -427,10 +427,10 @@ class ChoicesOffline extends Component
                                    @if($allowAll)
                                        <div
                                             wire:key="allow-all-{{ rand() }}"
-                                            class="font-bold border border-s-4 border-b-base-200 hover:bg-base-200"
+                                            class="{{ Mary::classes('font-bold border border-s-4 border-b-base-200 hover:bg-base-200') }}"
                                        >
-                                            <div x-show="!isAllSelected" @click="selectAll()" class="p-3 underline decoration-wavy decoration-info">{{ $allowAllText }}</div>
-                                            <div x-show="isAllSelected" @click="reset()" class="p-3 underline decoration-wavy decoration-error">{{ $removeAllText }}</div>
+                                            <div x-show="!isAllSelected" @click="selectAll()" class="{{ Mary::classes('p-3 underline decoration-wavy decoration-info') }}">{{ $allowAllText }}</div>
+                                            <div x-show="isAllSelected" @click="reset()" class="{{ Mary::classes('p-3 underline decoration-wavy decoration-error') }}">{{ $removeAllText }}</div>
                                        </div>
                                    @endif
 
@@ -438,7 +438,7 @@ class ChoicesOffline extends Component
                                     <div
                                         x-show="noResults"
                                         wire:key="no-results-{{ rand() }}"
-                                        class="p-3 decoration-wavy decoration-warning underline font-bold border border-s-4 border-s-warning border-b-base-200"
+                                        class="{{ Mary::classes('p-3 decoration-wavy decoration-warning underline font-bold border border-s-4 border-s-warning border-b-base-200') }}"
                                     >
                                         {{ $noResultText }}
                                     </div>
@@ -450,9 +450,9 @@ class ChoicesOffline extends Component
                                                 wire:key="option-{{ data_get($option, $optionValue) }}"
                                                 @click="toggle({{ $getOptionValue($option) }}, true)"
                                                 @keydown.enter="toggle({{ $getOptionValue($option) }}, true)"
-                                                :class="isActive({{ $getOptionValue($option) }}) && 'border-s-4 border-s-base-content'"
+                                                :class="isActive({{ $getOptionValue($option) }}) && '{{ Mary::classes('border-s-4 border-s-base-content') }}'"
                                                 search-value="{{ data_get($option, $optionLabel) }}"
-                                                class="border-s-4 border-base-content/10 focus:bg-base-200 focus:outline-none"
+                                                class="{{ Mary::classes('border-s-4 border-base-content/10 focus:bg-base-200 focus:outline-none') }}"
                                                 tabindex="0"
                                             >
                                                 {{-- ITEM SLOT --}}
@@ -464,7 +464,7 @@ class ChoicesOffline extends Component
 
                                                 {{-- SELECTION SLOT --}}
                                                 @if($selection)
-                                                    <span id="selection-{{ $uuid }}-{{ data_get($option, $optionValue) }}" class="hidden">
+                                                    <span id="selection-{{ $uuid }}-{{ data_get($option, $optionValue) }}" class="{{ Mary::classes('hidden') }}">
                                                         {{ $selection($option) }}
                                                     </span>
                                                 @endif

--- a/src/View/Components/Code.php
+++ b/src/View/Components/Code.php
@@ -17,13 +17,13 @@ class Code extends Component
         public string $language = 'javascript',
         public ?string $lightTheme = 'github_light_default',
         public ?string $darkTheme = 'github_dark',
-        public ?string $lightClass = "light",
-        public ?string $darkClass = "dark",
+        public ?string $lightClass = 'light',
+        public ?string $darkClass = 'dark',
         public string $height = '200px',
         public string $lineHeight = '2',
         public bool $printMargin = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -36,10 +36,10 @@ class Code extends Component
         return <<<'BLADE'
             <div>
                 @if($label)
-                    <div class="text-xs font-semibold mt-5 mb-3">{{ $label }}</div>
+                    <div class="{{ Mary::classes('text-xs font-semibold mt-5 mb-3') }}">{{ $label }}</div>
                 @endif
 
-                <div {{ $attributes->whereStartsWith('class')->class(["textarea w-full p-0", "textarea-error" => $errors->has($modelName())]) }} >
+                <div {{ $attributes->whereStartsWith('class')->maryClass(["textarea w-full p-0", "textarea-error" => $errors->has($modelName())]) }} >
                     <div
                         wire:ignore
                         x-data="{
@@ -98,11 +98,11 @@ class Code extends Component
                 </div>
 
                 @error($modelName())
-                    <div class="text-error text-xs mt-3">{{ $message }}</div>
+                    <div class="{{ Mary::classes('text-error text-xs mt-3') }}">{{ $message }}</div>
                 @enderror
 
                 @if($hint)
-                    <div class="text-xs text-base-content/50 mt-2">{{ $hint }}</div>
+                    <div class="{{ Mary::classes('text-xs text-base-content/50 mt-2') }}">{{ $hint }}</div>
                 @endif
             </div>
         BLADE;

--- a/src/View/Components/Collapse.php
+++ b/src/View/Components/Collapse.php
@@ -23,7 +23,7 @@ class Collapse extends Component
         public mixed $heading = null,
         public mixed $content = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function progressTarget(): ?string
@@ -42,7 +42,7 @@ class Collapse extends Component
 
                 <div
                     {{
-                        $attributes->class([
+                        $attributes->maryClass([
                             'collapse border-[length:var(--border)] border-base-content/10',
                             'join-item' => !$noJoin,
                             'collapse-arrow' => !$collapsePlusMinus && !$noIcon,
@@ -60,23 +60,23 @@ class Collapse extends Component
                         @endif
 
                         <div
-                            {{ $heading->attributes->merge(["class" => "collapse-title font-semibold"]) }}
+                            {{ $heading->attributes->class(Mary::classes('collapse-title font-semibold')) }}
 
                             @if(isset($noJoin))
-                                :class="model == '{{ $name }}' && 'z-10'"
+                                :class="model == '{{ $name }}' && '{{ Mary::classes('z-10') }}'"
                                 @click="if (model == '{{ $name }}') model = null"
                             @endif
                         >
                             {{ $heading }}
                         </div>
-                        <div {{ $content->attributes->merge(["class" => "collapse-content"]) }} wire:key="content-{{ $uuid }}">
+                        <div {{ $content->attributes->class(Mary::classes('collapse-content')) }} wire:key="content-{{ $uuid }}">
                             @if($separator)
-                                <hr class="mb-3 border-t-[length:var(--border)] border-base-content/10" />
+                                <hr class="{{ Mary::classes('mb-3 border-t-[length:var(--border)] border-base-content/10') }}" />
 
                                 @if($progressIndicator)
-                                    <div class="h-0.5 -mt-6.5 mb-6.5">
+                                    <div class="{{ Mary::classes('h-0.5 -mt-6.5 mb-6.5') }}">
                                         <progress
-                                            class="progress progress-primary w-full h-0.5"
+                                            class="{{ Mary::classes('progress progress-primary w-full h-0.5') }}"
                                             wire:loading
 
                                             @if($progressTarget())

--- a/src/View/Components/Colorpicker.php
+++ b/src/View/Components/Colorpicker.php
@@ -16,26 +16,26 @@ class Colorpicker extends Component
         public ?string $icon = '',
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $prefix = null,
         public ?string $suffix = null,
         public ?bool $inline = false,
         public ?bool $clearable = false,
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -67,21 +67,21 @@ class Colorpicker extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -91,33 +91,33 @@ class Colorpicker extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div class="w-full join">
+                        <div class="{{ Mary::classes('w-full join') }}">
                              {{-- COLOR PICKER --}}
                              <label
                                 x-on:click="$refs.colorpicker.click()"
-                                :class="!$wire.{{ $modelName() }} && 'bg-[repeating-linear-gradient(45deg,_#ddd_0px,_#ddd_1px,_transparent_1px,_transparent_5px)]'"
+                                :class="!$wire.{{ $modelName() }} && '{{ Mary::classes('bg-[repeating-linear-gradient(45deg,_#ddd_0px,_#ddd_1px,_transparent_1px,_transparent_5px)]') }}'"
                                 :style="{ backgroundColor: $wire.{{ $modelName() }} }"
-                                @class(["input join-item w-12 p-0", "border border-dashed" => $isReadonly()])
+                                @maryClass(["input join-item w-12 p-0", "border border-dashed" => $isReadonly()])
                              >
                                 <input
                                     type="color"
-                                    class="cursor-pointer opacity-0 join-item"
+                                    class="{{ Mary::classes('cursor-pointer opacity-0 join-item') }}"
                                     x-ref="colorpicker"
                                     x-on:click.stop=""
                                     :style="{ backgroundColor: $wire.{{ $modelName() }} }"
-                                    @class(["border-dashed" => $isReadonly()])
+                                    @maryClass(["border-dashed" => $isReadonly()])
                                     {{ $attributes->wire('model') }}
 
                                     @if($isDisabled() || $isReadonly())
@@ -129,7 +129,7 @@ class Colorpicker extends Component
                             {{-- THE LABEL THAT HOLDS THE INPUT --}}
                             <label
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "input join-item w-full",
                                         "border-dashed" => $isReadonly(),
                                         "!input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
@@ -138,12 +138,12 @@ class Colorpicker extends Component
                              >
                                 {{-- PREFIX --}}
                                 @if($prefix)
-                                    <span class="label">{{ $prefix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                 @endif
 
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 -ms-1 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 -ms-1 opacity-40') }}" />
                                 @endif
 
                                 {{-- INPUT --}}
@@ -155,12 +155,12 @@ class Colorpicker extends Component
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
 
                                 {{-- SUFFIX --}}
                                 @if($suffix)
-                                    <span class="label">{{ $suffix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                 @endif
                             </label>
                         </div>
@@ -170,7 +170,7 @@ class Colorpicker extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -179,7 +179,7 @@ class Colorpicker extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/DatePicker.php
+++ b/src/View/Components/DatePicker.php
@@ -17,14 +17,14 @@ class DatePicker extends Component
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?bool $inline = false,
         public ?bool $clearable = false,
         public ?array $config = [],
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
@@ -34,11 +34,11 @@ class DatePicker extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -64,10 +64,10 @@ class DatePicker extends Component
     public function setup(): string
     {
         // Handle `wire:model.live` for `range` dates
-        if (isset($this->config["mode"]) && $this->config["mode"] == "range" && $this->attributes->wire('model')->hasModifier('live')) {
+        if (isset($this->config['mode']) && $this->config['mode'] == 'range' && $this->attributes->wire('model')->hasModifier('live')) {
             $this->attributes->setAttributes([
                 'wire:model' => $this->modelName(),
-                'live' => true
+                'live' => true,
             ]);
         }
 
@@ -79,13 +79,13 @@ class DatePicker extends Component
             'defaultDate' => '#model#',
             'plugins' => ['#plugins#'],
             'disable' => ['#disable#'],
-        ], Arr::except($this->config, ["plugins"])));
+        ], Arr::except($this->config, ['plugins'])));
 
         // Plugins
-        $plugins = "";
+        $plugins = '';
 
         foreach (Arr::get($this->config, 'plugins', []) as $plugin) {
-            $plugins .= "new " . key($plugin) . "( " . json_encode(current($plugin)) . " ),";
+            $plugins .= 'new ' . key($plugin) . '( ' . json_encode(current($plugin)) . ' ),';
         }
 
         $config = str_replace('"#plugins#"', $plugins, $config);
@@ -114,21 +114,21 @@ class DatePicker extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -138,14 +138,14 @@ class DatePicker extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
@@ -206,7 +206,7 @@ class DatePicker extends Component
                                 },
                             }"
 
-                            @class(["w-full", "join" => $prepend || $append])
+                            @maryClass(["w-full", "join" => $prepend || $append])
                         >
                             {{-- PREPEND --}}
                             @if($prepend)
@@ -224,7 +224,7 @@ class DatePicker extends Component
                                 @endif
 
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "input w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $isReadonly(),
@@ -234,11 +234,11 @@ class DatePicker extends Component
                              >
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 -ms-1 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 -ms-1 opacity-40') }}" />
                                 @endif
 
                                 {{-- PLACEHOLDER --}}
-                                <span :class="(focused || !isValueEmpty || !isRange || !isLive) && 'hidden'" class="text-base-content/40">
+                                <span :class="(focused || !isValueEmpty || !isRange || !isLive) && '{{ Mary::classes('hidden') }}'" class="{{ Mary::classes('text-base-content/40') }}">
                                     {{ $attributes->get('placeholder') }}
                                 </span>
 
@@ -246,19 +246,19 @@ class DatePicker extends Component
                                 <div
                                     x-init="instance = flatpickr($refs.input, {{ $setup() }});"
                                     x-on:livewire:navigating.window="instance.destroy();"
-                                    class="w-full"
+                                    class="{{ Mary::classes('w-full') }}"
                                 >
                                     <input x-ref="input" {{ $attributes->merge(['type' => 'date']) }} />
                                 </div>
 
                                 {{-- CLEAR ICON --}}
                                 @if($clearable)
-                                    <x-mary-icon @click.prevent="reset()" x-show="!isValueEmpty" name="o-x-mark" class="cursor-pointer w-4 h-4 opacity-40"/>
+                                    <x-mary-icon @click.prevent="reset()" x-show="!isValueEmpty" name="o-x-mark" class="{{ Mary::classes('cursor-pointer w-4 h-4 opacity-40') }}"/>
                                 @endif
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
                             </label>
 
@@ -273,7 +273,7 @@ class DatePicker extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -282,7 +282,7 @@ class DatePicker extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/DateTime.php
+++ b/src/View/Components/DateTime.php
@@ -16,12 +16,12 @@ class DateTime extends Component
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?bool $inline = false,
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
@@ -31,12 +31,12 @@ class DateTime extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -58,21 +58,21 @@ class DateTime extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -82,19 +82,19 @@ class DateTime extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div @class(["w-full", "join" => $prepend || $append])>
+                        <div @maryClass(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}
@@ -103,7 +103,7 @@ class DateTime extends Component
                             {{-- THE LABEL THAT HOLDS THE INPUT --}}
                             <label
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "input w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -114,19 +114,19 @@ class DateTime extends Component
 
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 -ms-1 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 -ms-1 opacity-40') }}" />
                                 @endif
 
                                 {{-- INPUT --}}
                                 <input
                                     id="{{ $uuid }}"
-                                    class="!grid"
+                                    class="{{ Mary::classes('!grid') }}"
                                     {{ $attributes->whereDoesntStartWith('class')->merge(['type' => 'date']) }}
                                 />
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
                             </label>
 
@@ -141,7 +141,7 @@ class DateTime extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -150,7 +150,7 @@ class DateTime extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/Diff.php
+++ b/src/View/Components/Diff.php
@@ -18,7 +18,7 @@ class Diff extends Component
         public string $fileName = 'payload.json',
         public ?array $config = []
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function setup(): string
@@ -50,7 +50,7 @@ class Diff extends Component
                         }
                 }"
              >
-                <div x-ref="diff{{ $uuid }}" class="[&_.d2h-diff-table]:!text-xs [&_.d2h-file-header]:!bg-base-100 [&_.d2h-file-wrapper]:!border-dashed [&_.d2h-file-wrapper]:!border-[length:var(--border)] [&_.d2h-file-wrapper]:!bg-base-100 [&_.d2h-del]:!bg-red-50 [&_.d2h-ins]:!bg-green-50 [&_.d2h-code-line-ctn]:!whitespace-pre-wrap [&_.d2h-code-side-line]:!w-auto">
+                <div x-ref="diff{{ $uuid }}" class="{{ Mary::classes('[&_.d2h-diff-table]:!text-xs [&_.d2h-file-header]:!bg-base-100 [&_.d2h-file-wrapper]:!border-dashed [&_.d2h-file-wrapper]:!border-[length:var(--border)] [&_.d2h-file-wrapper]:!bg-base-100 [&_.d2h-del]:!bg-red-50 [&_.d2h-ins]:!bg-green-50 [&_.d2h-code-line-ctn]:!whitespace-pre-wrap [&_.d2h-code-side-line]:!w-auto') }}">
                 </div>
             </div>
         HTML;

--- a/src/View/Components/Drawer.php
+++ b/src/View/Components/Drawer.php
@@ -22,10 +22,10 @@ class Drawer extends Component
         public ?bool $withoutTrapFocus = false,
         public ?bool $withoutBackdropClose = false,
 
-        //Slots
+        // Slots
         public ?string $actions = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function id(): string
@@ -66,7 +66,7 @@ class Drawer extends Component
                         x-trap="open" x-bind:inert="!open"
                     @endif
 
-                    @class(["drawer absolute z-50", "drawer-end" => $right])
+                    @maryClass(["drawer absolute z-50", "drawer-end" => $right])
 
                     {{ $attributes->whereStartsWith('@') }}
                 >
@@ -76,14 +76,14 @@ class Drawer extends Component
                         x-model="open"
                         x-ref="checkbox"
                         type="checkbox"
-                        class="drawer-toggle" />
+                        class="{{ Mary::classes('drawer-toggle') }}" />
 
-                    <div class="drawer-side" >
+                    <div class="{{ Mary::classes('drawer-side') }}" >
                         <!-- Overlay effect , click outside -->
                         @if($withoutBackdropClose)
-                            <div class="drawer-overlay pointer-events-none"></div>
+                            <div class="{{ Mary::classes('drawer-overlay pointer-events-none') }}"></div>
                         @else
-                            <label for="{{ $id() }}" class="drawer-overlay"></label>
+                            <label for="{{ $id() }}" class="{{ Mary::classes('drawer-overlay') }}"></label>
                         @endif
 
                         <!-- Content -->
@@ -92,11 +92,11 @@ class Drawer extends Component
                             :subtitle="$subtitle"
                             :separator="$separator"
                             wire:key="drawer-card"
-                            {{ $attributes->except('wire:model')->class(['min-h-screen rounded-none px-8']) }}
+                            {{ $attributes->except('wire:model')->maryClass(['min-h-screen rounded-none px-8']) }}
                         >
                             @if($withCloseButton)
                                 <x-slot:menu>
-                                    <x-mary-button icon="o-x-mark" class="btn-ghost btn-sm btn-circle" @click="close()" />
+                                    <x-mary-button icon="o-x-mark" class="{{ Mary::classes('btn-ghost btn-sm btn-circle') }}" @click="close()" />
                                 </x-slot:menu>
                             @endif
 

--- a/src/View/Components/Dropdown.php
+++ b/src/View/Components/Dropdown.php
@@ -22,7 +22,7 @@ class Dropdown extends Component
         // Slots
         public mixed $trigger = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -32,7 +32,7 @@ class Dropdown extends Component
                 x-data="{open: false}"
                 @click.outside="open = false"
                 :open="open"
-                @class([
+                @maryClass([
                     'overflow-visible',
                     'dropdown',
                     'dropdown-end' => ($noXAnchor && $right),
@@ -42,19 +42,19 @@ class Dropdown extends Component
             >
                 <!-- CUSTOM TRIGGER -->
                 @if($trigger)
-                    <summary x-ref="button" @click.prevent="open = !open" {{ $trigger->attributes->class(['list-none']) }}>
+                    <summary x-ref="button" @click.prevent="open = !open" {{ $trigger->attributes->maryClass(['list-none']) }}>
                         {{ $trigger }}
                     </summary>
                 @else
                     <!-- DEFAULT TRIGGER -->
-                    <summary x-ref="button" @click.prevent="open = !open" {{ $attributes->class(["btn"]) }}>
+                    <summary x-ref="button" @click.prevent="open = !open" {{ $attributes->maryClass(["btn"]) }}>
                         {{ $label }}
                         <x-mary-icon :name="$icon" />
                     </summary>
                 @endif
 
                 <ul
-                    @class([
+                    @maryClass([
                         'p-2','shadow','menu','z-[1]','border-[length:var(--border)]','border-base-content/10','bg-base-100', 'rounded-box','w-auto','min-w-max',
                         'dropdown-content' => $noXAnchor,
                         $maxHeight => $scroll,

--- a/src/View/Components/Editor.php
+++ b/src/View/Components/Editor.php
@@ -16,25 +16,25 @@ class Editor extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $disk = 'public',
         public ?string $folder = 'editor',
         public ?bool $gplLicense = false,
         public ?array $config = [],
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
         $this->uploadUrl = route('mary.upload', absolute: false);
     }
 
@@ -64,7 +64,7 @@ class Editor extends Component
 
         $setup['plugins'] = str('advlist autolink lists link image table quickbars ')->append($this->config['plugins'] ?? '');
 
-        return str(json_encode($setup))->trim('{}')->replace("\"", "'")->toString();
+        return str(json_encode($setup))->trim('{}')->replace('"', "'")->toString();
     }
 
     public function render(): View|Closure|string
@@ -76,21 +76,21 @@ class Editor extends Component
                 @endphp
 
                 <div>
-                    <fieldset class="fieldset py-0">
+                    <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
                             
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -176,7 +176,7 @@ class Editor extends Component
                         @if(!$omitError && $errors->has($errorFieldName()))
                             @foreach($errors->get($errorFieldName()) as $message)
                                 @foreach(Arr::wrap($message) as $line)
-                                    <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                    <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                     @break($firstErrorOnly)
                                 @endforeach
                                 @break($firstErrorOnly)
@@ -185,7 +185,7 @@ class Editor extends Component
 
                         {{-- HINT --}}
                         @if($hint)
-                            <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                            <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                         @endif
                     </fieldset>
                 </div>

--- a/src/View/Components/Errors.php
+++ b/src/View/Components/Errors.php
@@ -17,7 +17,7 @@ class Errors extends Component
         public ?string $icon = 'o-x-circle',
         public ?array $only = [],
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -25,24 +25,24 @@ class Errors extends Component
         return <<<'BLADE'
                 @if ($errors->any())
                     <div>
-                        <div {{ $attributes->class(["alert alert-error rounded rounded-sm"]) }} >
-                            <div class="grid gap-3">
-                                <div class="flex gap-2">
+                        <div {{ $attributes->maryClass(["alert alert-error rounded rounded-sm"]) }} >
+                            <div class="{{ Mary::classes('grid gap-3') }}">
+                                <div class="{{ Mary::classes('flex gap-2') }}">
                                     @if($title)
-                                        <x-mary-icon :name="$icon" class="w-6 h-6 mt-0.5" />
+                                        <x-mary-icon :name="$icon" class="{{ Mary::classes('w-6 h-6 mt-0.5') }}" />
                                     @endif
                                     <div>
                                         @if($title)
-                                            <div class="font-bold text-lg">{{ $title }}</div>
+                                            <div class="{{ Mary::classes('font-bold text-lg') }}">{{ $title }}</div>
                                         @endif
 
                                         @if($description)
-                                            <div class="font-semibold">{{ $description }}</div>
+                                            <div class="{{ Mary::classes('font-semibold') }}">{{ $description }}</div>
                                         @endif
                                     </div>
                                 </div>
                                 <div>
-                                    <ul class="list-disc ms-5 space-y-2 sm:ms-12 pb-3">
+                                    <ul class="{{ Mary::classes('list-disc ms-5 space-y-2 sm:ms-12 pb-3') }}">
                                        @foreach ($errors->all() as $error)
                                            <li>{{ $error }}</li>
                                        @endforeach

--- a/src/View/Components/File.php
+++ b/src/View/Components/File.php
@@ -14,30 +14,30 @@ class File extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?bool $hideProgress = false,
         public ?bool $cropAfterChange = false,
-        public ?string $changeText = "Change",
-        public ?string $cropTitleText = "Crop image",
-        public ?string $cropCancelText = "Cancel",
-        public ?string $cropSaveText = "Crop",
+        public ?string $changeText = 'Change',
+        public ?string $cropTitleText = 'Crop image',
+        public ?string $cropCancelText = 'Cancel',
+        public ?string $cropSaveText = 'Crop',
         public ?array $cropConfig = [],
-        public ?string $cropMimeType = "image/png",
+        public ?string $cropMimeType = 'image/png',
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -55,7 +55,7 @@ class File extends Component
         return json_encode(array_merge([
             'autoCropArea' => 1,
             'viewMode' => 1,
-            'dragMode' => 'move'
+            'dragMode' => 'move',
         ], $this->cropConfig));
     }
 
@@ -142,21 +142,21 @@ class File extends Component
 
                     {{ $attributes->whereStartsWith('class') }}
                 >
-                    <fieldset class="fieldset py-0">
+                    <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                         {{-- STANDARD LABEL --}}
                         @if($label)
-                            <legend class="fieldset-legend mb-0.5">
+                            <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                                 
                                 {{-- INPUT POPOVER --}}
                                 @if($popover)
                                     <x-mary-popover offset="5" position="top-start">
                                         <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                            <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                            <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                         </x-slot:trigger>
                                         <x-slot:content class="{{ $popoverContentClass }}">
                                             {{ $popover }}
@@ -172,8 +172,8 @@ class File extends Component
                                 x-cloak
                                 max="100"
                                 :value="progress"
-                                :class="!processing && 'hidden'"
-                                class="progress h-1 absolute -mt-2 w-56"></progress>
+                                :class="!processing && '{{ Mary::classes('hidden') }}'"
+                                class="{{ Mary::classes('progress h-1 absolute -mt-2 w-56') }}"></progress>
                         @endif
 
                         {{-- INPUT --}}
@@ -184,7 +184,7 @@ class File extends Component
                             @change="refreshImage()"
 
                             {{
-                                $attributes->whereDoesntStartWith('class')->class([
+                                $attributes->whereDoesntStartWith('class')->maryClass([
                                     "file-input w-full",
                                     "!file-input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError,
                                     "hidden" => $slot->isNotEmpty()
@@ -194,12 +194,12 @@ class File extends Component
 
                         @if ($slot->isNotEmpty())
                             <!-- PREVIEW AREA -->
-                            <div x-ref="preview" class="relative flex">
+                            <div x-ref="preview" class="{{ Mary::classes('relative flex') }}">
                                 <div
                                     wire:ignore
                                     @click="change()"
-                                    :class="processing && 'opacity-50 pointer-events-none'"
-                                    class="cursor-pointer hover:scale-105 transition-all tooltip"
+                                    :class="processing && '{{ Mary::classes('opacity-50 pointer-events-none') }}'"
+                                    class="{{ Mary::classes('cursor-pointer hover:scale-105 transition-all tooltip') }}"
                                     data-tip="{{ $changeText }}"
                                 >
                                     {{ $slot }}
@@ -208,19 +208,19 @@ class File extends Component
                                 <div
                                     x-cloak
                                     :style="`--value:${progress}; --size:1.5rem; --thickness: 4px;`"
-                                    :class="!processing && 'hidden'"
-                                    class="radial-progress text-success absolute top-5 start-5 bg-neutral"
+                                    :class="!processing && '{{ Mary::classes('hidden') }}'"
+                                    class="{{ Mary::classes('radial-progress text-success absolute top-5 start-5 bg-neutral') }}"
                                     role="progressbar"
                                 ></div>
                             </div>
 
                             <!-- CROP MODAL -->
                             <div @click.prevent="" x-ref="crop" wire:ignore>
-                                <x-mary-modal id="maryCrop{{ $uuid }}" x-ref="maryCrop" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="" without-trap-focus>
+                                <x-mary-modal id="maryCrop{{ $uuid }}" x-ref="maryCrop" :title="$cropTitleText" separator class="{{ Mary::classes('backdrop-blur-sm') }}" persistent @keydown.window.esc.prevent="" without-trap-focus>
                                     <img src="" />
                                     <x-slot:actions>
                                         <x-mary-button :label="$cropCancelText" @click="close()" />
-                                        <x-mary-button :label="$cropSaveText" class="btn-primary" @click="save()" ::disabled="processing" />
+                                        <x-mary-button :label="$cropSaveText" class="{{ Mary::classes('btn-primary') }}" @click="save()" ::disabled="processing" />
                                     </x-slot:actions>
                                 </x-mary-modal>
                             </div>
@@ -230,7 +230,7 @@ class File extends Component
                         @if(!$omitError && $errors->has($errorFieldName()))
                             @foreach($errors->get($errorFieldName()) as $message)
                                 @foreach(Arr::wrap($message) as $line)
-                                    <div class="{{ $errorClass }}" x-classes="text-error">{{ $line }}</div>
+                                    <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-classes="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                     @break($firstErrorOnly)
                                 @endforeach
                                 @break($firstErrorOnly)
@@ -239,12 +239,12 @@ class File extends Component
 
                         {{-- MULTIPLE --}}
                         @error($modelName().'.*')
-                            <div class="text-error" x-classes="text-error">{{ $message }}</div>
+                            <div class="{{ Mary::classes('text-error') }}" x-classes="{{ Mary::classes('text-error') }}">{{ $message }}</div>
                         @enderror
 
                         {{-- HINT --}}
                         @if($hint)
-                            <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                            <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                         @endif
                     </fieldset>
                 </div>

--- a/src/View/Components/Form.php
+++ b/src/View/Components/Form.php
@@ -22,19 +22,19 @@ class Form extends Component
         return <<<'BLADE'
                 <form
                     {{ $attributes->whereDoesntStartWith('class') }}
-                    {{ $attributes->class(['grid grid-flow-row auto-rows-min gap-3']) }}
+                    {{ $attributes->maryClass(['grid grid-flow-row auto-rows-min gap-3']) }}
                 >
 
                     {{ $slot }}
 
                     @if ($actions)
                         @if(!$noSeparator)
-                            <hr class="border-t-[length:var(--border)] border-base-content/10 my-3" />
+                            <hr class="{{ Mary::classes('border-t-[length:var(--border)] border-base-content/10 my-3') }}" />
                         @else
                             <div></div>
                         @endif
 
-                        <div {{ $actions->attributes->class(["flex justify-end gap-3"]) }}>
+                        <div {{ $actions->attributes->maryClass(["flex justify-end gap-3"]) }}>
                             {{ $actions}}
                         </div>
                     @endif

--- a/src/View/Components/Group.php
+++ b/src/View/Components/Group.php
@@ -15,18 +15,18 @@ class Group extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $optionValue = 'id',
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -43,19 +43,19 @@ class Group extends Component
     {
         return <<<'BLADE'
                 <div>
-                    <fieldset class="fieldset py-0">
+                    <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                         {{-- STANDARD LABEL --}}
                         @if($label)
-                            <legend class="fieldset-legend mb-0.5">
+                            <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </legend>
                         @endif
 
-                        <div class="join">
+                        <div class="{{ Mary::classes('join') }}">
                             @foreach ($options as $option)
                                 <input
                                     type="radio"
@@ -66,7 +66,7 @@ class Group extends Component
 
                                     {{ $attributes->whereStartsWith('wire:model') }}
                                     {{
-                                        $attributes->class([
+                                        $attributes->maryClass([
                                             "join-item btn [&:checked]:btn-neutral",
                                             "!border-l-base-100" => data_get($option, 'disabled')
                                         ])
@@ -79,7 +79,7 @@ class Group extends Component
                         @if(!$omitError && $errors->has($errorFieldName()))
                             @foreach($errors->get($errorFieldName()) as $message)
                                 @foreach(Arr::wrap($message) as $line)
-                                    <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                    <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                     @break($firstErrorOnly)
                                 @endforeach
                                 @break($firstErrorOnly)
@@ -88,7 +88,7 @@ class Group extends Component
 
                         {{-- HINT --}}
                         @if($hint)
-                            <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                            <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                         @endif
                     </fieldset>
                 </div>

--- a/src/View/Components/Header.php
+++ b/src/View/Components/Header.php
@@ -18,10 +18,10 @@ class Header extends Component
         public ?string $subtitle = null,
         public ?bool $separator = false,
         public ?string $progressIndicator = null,
-        public string $progressIndicatorClass = "progress-primary",
+        public ?string $progressIndicatorClass = null,
         public ?bool $withAnchor = false,
-        public ?string $size = 'text-2xl',
-        public ?string $weight = 'font-extrabold',
+        public ?string $size = null,
+        public ?string $weight = null,
         public ?bool $useH1 = false,
 
         // Icon
@@ -48,10 +48,10 @@ class Header extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div id="{{ $anchor }}" {{ $attributes->class(["mb-10", "mary-header-anchor" => $withAnchor]) }}>
-                    <div class="flex flex-wrap gap-5 justify-between items-center">
+                <div id="{{ $anchor }}" {{ $attributes->class(Mary::classes('mb-10')->addRaw(['mary-header-anchor' => $withAnchor])) }}>
+                    <div class="{{ Mary::classes('flex flex-wrap gap-5 justify-between items-center') }}">
                         <div>
-                            {!! "<{$titleTag}" !!} @class(["flex", "items-center", "$size $weight", is_string($title) ? '' : $title?->attributes->get('class') ]) >
+                            {!! "<{$titleTag}" !!} class="{{ Mary::classes('flex items-center')->add(is_null($size) ? 'text-2xl' : null)->add(is_null($weight) ? 'font-extrabold' : null)->addRaw($size)->addRaw($weight)->addRaw(is_string($title) ? '' : $title?->attributes->get('class')) }}" >
                                 @if($withAnchor)
                                     <a href="#{{ $anchor }}">
                                 @endif
@@ -60,7 +60,7 @@ class Header extends Component
                                     <x-mary-icon name="{{ $icon }}" class="{{ $iconClasses }}" />
                                 @endif
 
-                                <span @class(["ml-2" => $icon])>{{ $title }}</span>
+                                <span @maryClass(["ml-2" => $icon])>{{ $title }}</span>
 
                                 @if($withAnchor)
                                     </a>
@@ -68,34 +68,34 @@ class Header extends Component
                             {!! "</{$titleTag}>" !!}
 
                             @if($subtitle)
-                                <div @class(["text-base-content/50 text-sm mt-1", is_string($subtitle) ? '' : $subtitle?->attributes->get('class') ]) >
+                                <div class="{{ Mary::classes('text-base-content/50 text-sm mt-1')->addRaw(is_string($subtitle) ? '' : $subtitle?->attributes->get('class')) }}" >
                                     {{ $subtitle }}
                                 </div>
                             @endif
                         </div>
 
                         @if($middle)
-                            <div @class(["flex items-center justify-center gap-3 grow order-last sm:order-none", is_string($middle) ? '' : $middle?->attributes->get('class')])>
-                                <div class="w-full lg:w-auto">
+                            <div class="{{ Mary::classes('flex items-center justify-center gap-3 grow order-last sm:order-none')->addRaw(is_string($middle) ? '' : $middle?->attributes->get('class')) }}">
+                                <div class="{{ Mary::classes('w-full lg:w-auto') }}">
                                     {{ $middle }}
                                 </div>
                             </div>
                         @endif
 
                         @if($actions)
-                            <div @class(["flex items-center gap-3", is_string($actions) ? '' : $actions?->attributes->get('class') ]) >
+                            <div class="{{ Mary::classes('flex items-center gap-3')->addRaw(is_string($actions) ? '' : $actions?->attributes->get('class')) }}" >
                                 {{ $actions }}
                             </div>
                         @endif
                     </div>
 
                     @if($separator)
-                        <hr class="border-t-[length:var(--border)] border-base-content/10 mt-3" />
+                        <hr class="{{ Mary::classes('border-t-[length:var(--border)] border-base-content/10 mt-3') }}" />
 
                         @if($progressIndicator)
-                            <div class="h-0.5 -mt-4 mb-4">
+                            <div class="{{ Mary::classes('h-0.5 -mt-4 mb-4') }}">
                                 <progress
-                                    class="progress {{ $progressIndicatorClass }} w-full h-[var(--border)]"
+                                    class="{{ Mary::classes('progress w-full h-[var(--border)]')->add(is_null($progressIndicatorClass) ? 'progress-primary' : null)->addRaw($progressIndicatorClass) }}"
                                     wire:loading
 
                                     @if($progressTarget())

--- a/src/View/Components/Hr.php
+++ b/src/View/Components/Hr.php
@@ -14,7 +14,7 @@ class Hr extends Component
         public ?string $id = null,
         public ?string $target = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function progressTarget(): ?string
@@ -29,10 +29,10 @@ class Hr extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div {{ $attributes->class("h-[2px] border-t-[length:var(--border)] border-t-base-content/10 my-5") }}>
+                <div {{ $attributes->class(Mary::classes("h-[2px] border-t-[length:var(--border)] border-t-base-content/10 my-5")) }}>
                     <progress
-                        class="progress progress-primary hidden h-[1px]"
-                        wire:loading.class="!h-[length:var(--border)] !block"
+                        class="{{ Mary::classes('progress progress-primary hidden h-[1px]') }}"
+                        wire:loading.class="{{ Mary::classes('!h-[length:var(--border)] !block') }}"
 
                         @if($progressTarget())
                             wire:target="{{ $progressTarget() }}"

--- a/src/View/Components/Icon.php
+++ b/src/View/Components/Icon.php
@@ -17,7 +17,7 @@ class Icon extends Component
         public ?string $id = null,
         public ?string $label = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function icon(): string|Stringable
@@ -37,11 +37,11 @@ class Icon extends Component
     {
         return <<<'BLADE'
                 @if(strlen($label ?? '') > 0)
-                    <div class="inline-flex items-center gap-1">
+                    <div class="{{ Mary::classes('inline-flex items-center gap-1') }}">
                 @endif
                     <x-svg
                         :name="$icon()"
-                        {{ $attributes->class(['inline flex-shrink-0', 'w-5 h-5' => !Str::contains($attributes->get('class') ?? '', ['w-', 'h-']) ]) }}
+                        {{ $attributes->maryClass(['inline flex-shrink-0', 'w-5 h-5' => !Str::contains($attributes->get('class') ?? '', ['w-', 'h-']) ]) }}
                     />
 
                 @if(strlen($label ?? '') > 0)

--- a/src/View/Components/ImageGallery.php
+++ b/src/View/Components/ImageGallery.php
@@ -18,7 +18,7 @@ class ImageGallery extends Component
         public ?string $imgCss = null
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -38,10 +38,10 @@ class ImageGallery extends Component
                         }
                     }"
                 >
-                    <div id="gallery-{{ $uuid }}" {{ $attributes->class("pswp-gallery pswp-gallery--single-column carousel") }} >
+                    <div id="gallery-{{ $uuid }}" {{ $attributes->class((string) Mary::classes('carousel')->addRaw('pswp-gallery pswp-gallery--single-column')) }} >
                         @foreach($images as $image)
                             <a
-                                class="carousel-item h-full"
+                                class="{{ Mary::classes('carousel-item h-full') }}"
                                 href="{{ $image }}"
                                 target="_blank"
                                 data-pswp-width="200"
@@ -49,7 +49,7 @@ class ImageGallery extends Component
                             >
                                 <img
                                     src="{{ $image }}"
-                                    @class(["object-cover h-full hover:opacity-70", $imgCss])
+                                    class="{{ Mary::classes('object-cover h-full hover:opacity-70')->addRaw($imgCss) }}"
                                     onload="this.parentNode.setAttribute('data-pswp-width', this.naturalWidth); this.parentNode.setAttribute('data-pswp-height', this.naturalHeight)"
                                 />
                             </a>

--- a/src/View/Components/ImageLibrary.php
+++ b/src/View/Components/ImageLibrary.php
@@ -19,24 +19,24 @@ class ImageLibrary extends Component
         public ?string $hint = null,
         public ?bool $hideErrors = false,
         public ?bool $hideProgress = false,
-        public ?string $changeText = "Change",
-        public ?string $cropText = "Crop",
-        public ?string $removeText = "Remove",
-        public ?string $cropTitleText = "Crop image",
-        public ?string $cropCancelText = "Cancel",
-        public ?string $cropSaveText = "Crop",
-        public ?string $addFilesText = "Add images",
+        public ?string $changeText = 'Change',
+        public ?string $cropText = 'Crop',
+        public ?string $removeText = 'Remove',
+        public ?string $cropTitleText = 'Crop image',
+        public ?string $cropCancelText = 'Cancel',
+        public ?string $cropSaveText = 'Crop',
+        public ?string $addFilesText = 'Add images',
         public ?array $cropConfig = [],
         public Collection $preview = new Collection(),
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -139,21 +139,21 @@ class ImageLibrary extends Component
 
                 {{ $attributes->whereStartsWith('class') }}
             >
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
                             
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -165,27 +165,27 @@ class ImageLibrary extends Component
 
                     {{-- PREVIEW AREA --}}
                     <div
-                        :class="(processing || indeterminate) && 'opacity-50 pointer-events-none'"
-                        @class(["relative", "hidden" => $preview->count() == 0])
+                        :class="(processing || indeterminate) && '{{ Mary::classes('opacity-50 pointer-events-none') }}'"
+                        @maryClass(["relative", "hidden" => $preview->count() == 0])
                     >
                         <div
                             x-data="{ sortable: null }"
-                            x-init="sortable = new Sortable($el, { animation: 150, ghostClass: 'bg-base-300', filter: '.ignore-drag', onEnd: (ev) => refreshMediaOrder(sortable.toArray()) })"
-                            class="border-[length:var(--border)] border-base-content/10 border-dotted rounded-lg"
+                            x-init="sortable = new Sortable($el, { animation: 150, ghostClass: '{{ Mary::classes('bg-base-300') }}', filter: '.ignore-drag', onEnd: (ev) => refreshMediaOrder(sortable.toArray()) })"
+                            class="{{ Mary::classes('border-[length:var(--border)] border-base-content/10 border-dotted rounded-lg') }}"
                         >
                             @foreach($preview as $key => $image)
-                                <div class="relative border-b-base-content/10 border-b-[length:var(--border)] border-dotted last:border-none cursor-move hover:bg-base-200" data-id="{{ $image['uuid'] }}">
-                                    <div wire:key="preview-{{ $image['uuid'] }}" class="py-2 ps-16 pe-10 tooltip" data-tip="{{ $changeText }}">
+                                <div class="{{ Mary::classes('relative border-b-base-content/10 border-b-[length:var(--border)] border-dotted last:border-none cursor-move hover:bg-base-200') }}" data-id="{{ $image['uuid'] }}">
+                                    <div wire:key="preview-{{ $image['uuid'] }}" class="{{ Mary::classes('py-2 ps-16 pe-10 tooltip') }}" data-tip="{{ $changeText }}">
                                         {{-- IMAGE --}}
                                         <img
                                             src="{{ $image['url'] }}"
-                                            class="h-24 cursor-pointer border-2 border-base-content/10 rounded-lg hover:scale-105 transition-all ease-in-out"
+                                            class="{{ Mary::classes('h-24 cursor-pointer border-2 border-base-content/10 rounded-lg hover:scale-105 transition-all ease-in-out') }}"
                                             @click="document.getElementById('file-{{ $uuid}}-{{ $key }}').click()"
                                             id="image-{{ $modelName().'.'.$key  }}-{{ $uuid }}" />
 
                                         {{-- VALIDATION --}}
                                          @error($modelName().'.'.$key)
-                                            <div class="text-error label-text-alt p-1">{{ $validationMessage($message) }}</div>
+                                            <div class="{{ Mary::classes('text-error label-text-alt p-1') }}">{{ $validationMessage($message) }}</div>
                                          @enderror
 
                                         {{-- HIDDEN FILE INPUT --}}
@@ -194,15 +194,15 @@ class ImageLibrary extends Component
                                             id="file-{{ $uuid}}-{{ $key }}"
                                             wire:model="{{ $modelName().'.'.$key  }}"
                                             accept="{{ $attributes->get('accept') ?? $mimes }}"
-                                            class="hidden"
+                                            class="{{ Mary::classes('hidden') }}"
                                             @change="progress = 1"
                                             />
                                     </div>
 
                                     {{-- ACTIONS --}}
-                                    <div class="absolute flex flex-col gap-2 top-3 start-3 cursor-pointer  p-2 rounded-lg ignore-drag">
-                                        <x-mary-button @click="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')" @touchend.prevent="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')" icon="o-x-circle" :tooltip="$removeText"  class="btn-sm btn-ghost btn-circle" />
-                                        <x-mary-button @click="crop('image-{{ $modelName().'.'.$key  }}-{{ $uuid }}')" @touchend.prevent="crop('image-{{ $modelName().'.'.$key }}-{{ $uuid }}')" icon="o-scissors" :tooltip="$cropText"  class="btn-sm btn-ghost btn-circle" />
+                                    <div class="{{ Mary::classes('absolute flex flex-col gap-2 top-3 start-3 cursor-pointer p-2 rounded-lg')->addRaw('ignore-drag') }}">
+                                        <x-mary-button @click="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')" @touchend.prevent="removeMedia('{{ $image['uuid'] }}', '{{ $image['url'] }}')" icon="o-x-circle" :tooltip="$removeText"  class="{{ Mary::classes('btn-sm btn-ghost btn-circle') }}" />
+                                        <x-mary-button @click="crop('image-{{ $modelName().'.'.$key  }}-{{ $uuid }}')" @touchend.prevent="crop('image-{{ $modelName().'.'.$key }}-{{ $uuid }}')" icon="o-scissors" :tooltip="$cropText"  class="{{ Mary::classes('btn-sm btn-ghost btn-circle') }}" />
                                     </div>
                                 </div>
                             @endforeach
@@ -211,34 +211,34 @@ class ImageLibrary extends Component
 
                     {{-- CROP MODAL --}}
                     <div @click.prevent="" x-ref="crop" wire:ignore>
-                        <x-mary-modal id="maryCropModal{{ $uuid }}" x-ref="maryCropModal" :title="$cropTitleText" separator class="backdrop-blur-sm" persistent @keydown.window.esc.prevent="" without-trap-focus>
+                        <x-mary-modal id="maryCropModal{{ $uuid }}" x-ref="maryCropModal" :title="$cropTitleText" separator class="{{ Mary::classes('backdrop-blur-sm') }}" persistent @keydown.window.esc.prevent="" without-trap-focus>
                             <img src="#" crossOrigin="Anonymous" />
                             <x-slot:actions>
                                 <x-mary-button :label="$cropCancelText" @click="close()" />
-                                <x-mary-button :label="$cropSaveText" class="btn-primary" @click="save()" />
+                                <x-mary-button :label="$cropSaveText" class="{{ Mary::classes('btn-primary') }}" @click="save()" />
                             </x-slot:actions>
                         </x-mary-modal>
                     </div>
 
                     {{-- PROGRESS BAR  --}}
                     @if(! $hideProgress && $slot->isEmpty())
-                        <div class="-mt-2 h-1">
+                        <div class="{{ Mary::classes('-mt-2 h-1') }}">
                             <progress
                                 x-cloak
-                                :class="!processing && 'hidden'"
+                                :class="!processing && '{{ Mary::classes('hidden') }}'"
                                 :value="progress"
                                 max="100"
-                                class="progress progress-primary h-1 w-full"></progress>
+                                class="{{ Mary::classes('progress progress-primary h-1 w-full') }}"></progress>
 
                             <progress
                                 x-cloak
-                                :class="!indeterminate && 'hidden'"
-                                class="progress progress-primary h-1 w-full"></progress>
+                                :class="!indeterminate && '{{ Mary::classes('hidden') }}'"
+                                class="{{ Mary::classes('progress progress-primary h-1 w-full') }}"></progress>
                         </div>
                     @endif
 
                     {{-- ADD FILES --}}
-                    <div @click="$refs.files.click()" class="btn btn-block" :class="(processing || indeterminate) && 'opacity-50 pointer-events-none'">
+                    <div @click="$refs.files.click()" class="{{ Mary::classes('btn btn-block') }}" :class="(processing || indeterminate) && '{{ Mary::classes('opacity-50 pointer-events-none') }}'">
                         <x-mary-icon name="o-plus-circle" label="{{ $addFilesText }}" />
                     </div>
 
@@ -247,7 +247,7 @@ class ImageLibrary extends Component
                         id="{{ $uuid }}"
                         type="file"
                         x-ref="files"
-                        class="file-input file-input-border file-input-primary hidden"
+                        class="{{ Mary::classes('file-input file-input-border file-input-primary hidden') }}"
                         wire:model="{{ $modelName() }}.*"
                         accept="{{ $attributes->get('accept') ?? $mimes }}"
                         @change="progress = 1"
@@ -256,13 +256,13 @@ class ImageLibrary extends Component
                     {{-- ERROR --}}
                     @if (! $hideErrors)
                         @error($libraryName())
-                            <div class="text-error">{{ $message }}</div>
+                            <div class="{{ Mary::classes('text-error') }}">{{ $message }}</div>
                         @enderror
                     @endif
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                </fieldset>
             </div>

--- a/src/View/Components/Input.php
+++ b/src/View/Components/Input.php
@@ -16,7 +16,7 @@ class Input extends Component
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $prefix = null,
         public ?string $suffix = null,
         public ?bool $inline = false,
@@ -24,9 +24,9 @@ class Input extends Component
         public ?bool $money = false,
         public ?string $locale = 'en-US',
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
@@ -36,11 +36,11 @@ class Input extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -68,8 +68,8 @@ class Input extends Component
         return json_encode([
             'init' => true,
             'maskOpts' => [
-                'locales' => $this->locale
-            ]
+                'locales' => $this->locale,
+            ],
         ]);
     }
 
@@ -82,21 +82,21 @@ class Input extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -106,19 +106,19 @@ class Input extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div @class(["w-full", "join" => $prepend || $append])>
+                        <div @maryClass(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}
@@ -131,7 +131,7 @@ class Input extends Component
                                 @endif
 
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "input w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $isReadonly(),
@@ -141,18 +141,18 @@ class Input extends Component
                              >
                                 {{-- PREFIX --}}
                                 @if($prefix)
-                                    <span class="label">{{ $prefix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                 @endif
 
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
 
                                 {{-- MONEY SETUP --}}
                                 @if($money)
                                     <div
-                                        class="w-full"
+                                        class="{{ Mary::classes('w-full') }}"
                                         x-data="{
                                             amount: $wire.get('{{ $modelName() }}'),
                                             currency: null,
@@ -202,17 +202,17 @@ class Input extends Component
 
                                 {{-- CLEAR ICON  --}}
                                 @if($clearable)
-                                    <x-mary-icon x-on:click="$wire.set('{{ $modelName() }}', '', {{ json_encode($attributes->wire('model')->hasModifier('live')) }})"  name="o-x-mark" class="cursor-pointer w-4 h-4 opacity-40"/>
+                                    <x-mary-icon x-on:click="$wire.set('{{ $modelName() }}', '', {{ json_encode($attributes->wire('model')->hasModifier('live')) }})"  name="o-x-mark" class="{{ Mary::classes('cursor-pointer w-4 h-4 opacity-40') }}"/>
                                 @endif
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
 
                                 {{-- SUFFIX --}}
                                 @if($suffix)
-                                    <span class="label">{{ $suffix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                 @endif
                             </label>
 
@@ -227,7 +227,7 @@ class Input extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -236,7 +236,7 @@ class Input extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/Kbd.php
+++ b/src/View/Components/Kbd.php
@@ -13,7 +13,7 @@ class Kbd extends Component
     public function __construct(
         public ?string $id = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -21,7 +21,7 @@ class Kbd extends Component
         return <<<'HTML'
                 <kbd
                     wire:key="{{ $uuid }}"
-                    {{ $attributes->merge(["class" => "kbd"]) }}
+                    {{ $attributes->class(Mary::classes('kbd')) }}
                 >
                     {{ $slot }}
                 </kbd>

--- a/src/View/Components/ListItem.php
+++ b/src/View/Components/ListItem.php
@@ -24,7 +24,7 @@ class ListItem extends Component
         // Slots
         public mixed $actions = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -32,7 +32,7 @@ class ListItem extends Component
         return <<<'HTML'
             <div wire:key="{{ $uuid }}">
                 <div
-                    {{ $attributes->class([
+                    {{ $attributes->maryClass([
                             "flex justify-start items-center gap-4 px-3 py-3",
                             "hover:bg-base-200" => !$noHover,
                             "cursor-pointer" => $link
@@ -48,8 +48,8 @@ class ListItem extends Component
                     <!-- AVATAR -->
                     @if(data_get($item, $avatar) || $fallbackAvatar && is_string($avatar))
                         <div>
-                            <div class="avatar">
-                                <div class="w-11 rounded-full">
+                            <div class="{{ Mary::classes('avatar') }}">
+                                <div class="{{ Mary::classes('w-11 rounded-full') }}">
                                     <img src="{{ data_get($item, $avatar) }}" @if($fallbackAvatar) onerror="this.src='{{ $fallbackAvatar }}'" @endif />
                                 </div>
                             </div>
@@ -57,7 +57,7 @@ class ListItem extends Component
                     @endif
 
                     @if(!is_string($avatar))
-                        <div {{ $avatar->attributes->class([]) }}>
+                        <div {{ $avatar->attributes->maryClass([]) }}>
                             {{ $avatar }}
                         </div>
                     @endif
@@ -69,17 +69,17 @@ class ListItem extends Component
                     @endif
 
                     <!-- CONTENT -->
-                    <div class="flex-1 overflow-hidden whitespace-nowrap text-ellipsis truncate mary-hideable">
+                    <div class="{{ Mary::classes('flex-1 overflow-hidden whitespace-nowrap text-ellipsis truncate')->addRaw('mary-hideable') }}">
                         @if($link)
                             <a href="{{ $link }}" wire:navigate>
                         @endif
 
                         <div>
-                            <div @if(!is_string($value)) {{ $value->attributes->class(["font-semibold truncate"]) }} @else class="font-semibold truncate" @endif>
+                            <div @if(!is_string($value)) {{ $value->attributes->maryClass(["font-semibold truncate"]) }} @else class="{{ Mary::classes('font-semibold truncate') }}" @endif>
                                 {{ is_string($value) ? data_get($item, $value) : $value }}
                             </div>
 
-                            <div @if(!is_string($subValue))  {{ $subValue->attributes->class(["text-base-content/50 text-sm truncate"]) }} @else class="text-base-content/50 text-sm truncate" @endif>
+                            <div @if(!is_string($subValue))  {{ $subValue->attributes->maryClass(["text-base-content/50 text-sm truncate"]) }} @else class="{{ Mary::classes('text-base-content/50 text-sm truncate') }}" @endif>
                                 {{ is_string($subValue) ? data_get($item, $subValue) : $subValue }}
                             </div>
                         </div>
@@ -94,7 +94,7 @@ class ListItem extends Component
                         @if($link && !Str::of($actions)->contains([':click', '@click' , 'href']))
                             <a href="{{ $link }}" wire:navigate>
                         @endif
-                            <div {{ $actions->attributes->class(["flex items-center gap-3 mary-hideable"]) }}>
+                            <div {{ $actions->attributes->class(Mary::classes('flex items-center gap-3')->addRaw('mary-hideable')) }}>
                                     {{ $actions }}
                             </div>
 
@@ -105,7 +105,7 @@ class ListItem extends Component
                 </div>
 
                 @if(!$noSeparator)
-                    <hr class="border-t-[length:var(--border)] border-base-content/10"/>
+                    <hr class="{{ Mary::classes('border-t-[length:var(--border)] border-base-content/10') }}"/>
                 @endif
             </div>
         HTML;

--- a/src/View/Components/Loading.php
+++ b/src/View/Components/Loading.php
@@ -13,13 +13,13 @@ class Loading extends Component
     public function __construct(
         public ?string $id = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <span {{ $attributes->class("loading") }}></span>
+                <span {{ $attributes->class(Mary::classes("loading")) }}></span>
             HTML;
     }
 }

--- a/src/View/Components/Main.php
+++ b/src/View/Components/Main.php
@@ -28,14 +28,14 @@ class Main extends Component
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
-                 <main @class(["w-full mx-auto", "max-w-screen-2xl" => !$fullWidth])>
-                    <div @class([
+                 <main @maryClass(["w-full mx-auto", "max-w-screen-2xl" => !$fullWidth])>
+                    <div @maryClass([
                         "drawer lg:drawer-open",
                         "drawer-end" => $sidebar?->attributes['right'],
                         "max-sm:drawer-end" => $sidebar?->attributes['right-mobile'],
                     ])>
-                        <input id="{{ $sidebar?->attributes['drawer'] }}" type="checkbox" class="drawer-toggle" />
-                        <div {{ $content->attributes->class(["drawer-content w-full mx-auto p-5 lg:px-10 lg:py-5"]) }}>
+                        <input id="{{ $sidebar?->attributes['drawer'] }}" type="checkbox" class="{{ Mary::classes('drawer-toggle') }}" />
+                        <div {{ $content->attributes->maryClass(["drawer-content w-full mx-auto p-5 lg:px-10 lg:py-5"]) }}>
                             {{-- MAIN CONTENT  --}}
                             {{ $content }}
                         </div>
@@ -54,18 +54,18 @@ class Main extends Component
                                 }"
 
                                 @menu-sub-clicked="if(collapsed) { toggle() }"
-                                @class(["drawer-side z-20 lg:z-auto", "top-0 lg:top-[65px] lg:h-[calc(100vh-65px)]" => $withNav])
+                                @maryClass(["drawer-side z-20 lg:z-auto", "top-0 lg:top-[65px] lg:h-[calc(100vh-65px)]" => $withNav])
                             >
-                                <label for="{{ $sidebar?->attributes['drawer'] }}" aria-label="close sidebar" class="drawer-overlay"></label>
+                                <label for="{{ $sidebar?->attributes['drawer'] }}" aria-label="close sidebar" class="{{ Mary::classes('drawer-overlay') }}"></label>
 
                                 {{-- SIDEBAR CONTENT  --}}
                                 <div
                                     :class="collapsed
-                                        ? '!w-[62px] [&>*_summary::after]:!hidden [&_.mary-hideable]:!hidden [&_.display-when-collapsed]:!block [&_.hidden-when-collapsed]:!hidden'
-                                        : '!w-[270px] [&>*_summary::after]:!block [&_.mary-hideable]:!block [&_.hidden-when-collapsed]:!block [&_.display-when-collapsed]:!hidden'"
+                                        ? '{{ Mary::classes('!w-[62px] [&>*_summary::after]:!hidden [&_.mary-hideable]:!hidden [&_.display-when-collapsed]:!block [&_.hidden-when-collapsed]:!hidden') }}'
+                                        : '{{ Mary::classes('!w-[270px] [&>*_summary::after]:!block [&_.mary-hideable]:!block [&_.hidden-when-collapsed]:!block [&_.display-when-collapsed]:!hidden') }}'"
 
                                     {{
-                                        $sidebar->attributes->class([
+                                        $sidebar->attributes->maryClass([
                                             "flex flex-col !transition-all !duration-100 ease-out overflow-x-hidden overflow-y-auto h-screen",
                                             "w-[62px] [&>*_summary::after]:hidden [&_.mary-hideable]:hidden [&_.display-when-collapsed]:block [&_.hidden-when-collapsed]:hidden" => session('mary-sidebar-collapsed') == 'true',
                                             "w-[270px] [&>*_summary::after]:block [&_.mary-hideable]:block [&_.hidden-when-collapsed]:block [&_.display-when-collapsed]:hidden" => session('mary-sidebar-collapsed') != 'true',
@@ -73,13 +73,13 @@ class Main extends Component
                                         ])
                                      }}
                                 >
-                                    <div class="flex-1">
+                                    <div class="{{ Mary::classes('flex-1') }}">
                                         {{ $sidebar }}
                                     </div>
 
                                      {{-- SIDEBAR COLLAPSE  --}}
                                     @if($sidebar->attributes['collapsible'])
-                                    <x-mary-menu class="hidden lg:block">
+                                    <x-mary-menu class="{{ Mary::classes('hidden lg:block') }}">
                                         <x-mary-menu-item
                                             @click="toggle"
                                             icon="{{ $sidebar->attributes['collapse-icon'] ?? $collapseIcon }}"
@@ -96,7 +96,7 @@ class Main extends Component
 
                  {{-- FOOTER  --}}
                  @if($footer)
-                    <footer {{ $footer?->attributes->class(["mx-auto w-full", "max-w-screen-2xl" => !$fullWidth ]) }}>
+                    <footer {{ $footer?->attributes->maryClass(["mx-auto w-full", "max-w-screen-2xl" => !$fullWidth ]) }}>
                         {{ $footer }}
                     </footer>
                 @endif

--- a/src/View/Components/Markdown.php
+++ b/src/View/Components/Markdown.php
@@ -16,24 +16,24 @@ class Markdown extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $disk = 'public',
         public ?string $folder = 'markdown',
         public ?array $config = [],
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
         $this->uploadUrl = route('mary.upload', absolute: false);
     }
 
@@ -71,7 +71,7 @@ class Markdown extends Component
                 'table',
                 '|',
                 'preview',
-                'side-by-side'
+                'side-by-side',
             ],
         ], $this->config);
 
@@ -80,7 +80,7 @@ class Markdown extends Component
         $table = "{ 'title' : 'Table', 'name' : 'myTable', 'action' : EasyMDE.drawTable, 'className' : 'fa fa-table' }";
 
         return str(json_encode($setup))
-            ->replace("\"", "'")
+            ->replace('"', "'")
             ->trim('{}')
             ->replace("'table'", $table)
             ->toString();
@@ -90,21 +90,21 @@ class Markdown extends Component
     {
         return <<<'HTML'
             <div>
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -167,12 +167,12 @@ class Markdown extends Component
                         wire:ignore
                         x-on:livewire:navigating.window="destroyEditor()"
                     >
-                        <div class="relative disabled text-base" :class="uploading && 'pointer-events-none opacity-50'">
+                        <div class="{{ Mary::classes('relative text-base')->addRaw('disabled') }}" :class="uploading && '{{ Mary::classes('pointer-events-none opacity-50') }}'">
                             <textarea id="{{ $uuid }}" x-ref="markdown{{ $uuid }}"></textarea>
 
-                            <div class="absolute top-1/2 start-1/2 !opacity-100 text-center hidden" :class="uploading && '!block'">
+                            <div class="{{ Mary::classes('absolute top-1/2 start-1/2 !opacity-100 text-center hidden') }}" :class="uploading && '{{ Mary::classes('!block') }}'">
                                 <div>Uploading</div>
-                                <div class="loading loading-dots"></div>
+                                <div class="{{ Mary::classes('loading loading-dots') }}"></div>
                             </div>
                         </div>
                     </div>
@@ -181,7 +181,7 @@ class Markdown extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -190,7 +190,7 @@ class Markdown extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/Menu.php
+++ b/src/View/Components/Menu.php
@@ -14,25 +14,25 @@ class Menu extends Component
         public ?string $id = null,
         public ?string $title = null,
         public ?string $icon = null,
-        public ?string $iconClasses = 'w-4 h-4',
+        public ?string $iconClasses = null,
         public ?bool $separator = false,
         public ?bool $activateByRoute = false,
-        public ?string $activeBgColor = 'bg-base-300',
+        public ?string $activeBgColor = null,
         public ?bool $horizontal = false
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
-                <ul {{ $attributes->class(["menu w-full", "menu-horizontal flex-nowrap overflow-x-auto scrollbar-none" => $horizontal]) }} >
+                <ul {{ $attributes->maryClass(["menu w-full", "menu-horizontal flex-nowrap overflow-x-auto scrollbar-none" => $horizontal]) }} >
                     @if($title)
-                        <li class="menu-title text-inherit uppercase">
-                            <div class="flex items-center gap-2">
+                        <li class="{{ Mary::classes('menu-title text-inherit uppercase') }}">
+                            <div class="{{ Mary::classes('flex items-center gap-2') }}">
 
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" @class(['inline-flex', $iconClasses])  />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('inline-flex')->add(is_null($iconClasses) ? 'w-4 h-4' : null)->addRaw($iconClasses) }}" />
                                 @endif
 
                                 {{ $title }}
@@ -41,7 +41,7 @@ class Menu extends Component
                     @endif
 
                     @if($separator)
-                        <hr class="mb-3 border-t-[length:var(--border)] border-base-content/10" />
+                        <hr class="{{ Mary::classes('mb-3 border-t-[length:var(--border)] border-base-content/10') }}" />
                     @endif
 
                     {{ $slot }}

--- a/src/View/Components/MenuItem.php
+++ b/src/View/Components/MenuItem.php
@@ -30,7 +30,7 @@ class MenuItem extends Component
         public ?bool $disabled = false,
         public ?bool $exact = false
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function spinnerTarget(): ?string
@@ -80,15 +80,21 @@ class MenuItem extends Component
         }
 
         return <<<'BLADE'
-                @aware(['horizontal' => false, 'activateByRoute' => false, 'activeBgColor' => 'bg-base-300'])
+                @aware(['horizontal' => false, 'activateByRoute' => false, 'activeBgColor' => null])
 
-                <li @class(['menu-disabled' => $disabled])>
+                @php
+                    $isActive = $active || ($activateByRoute && $routeMatches());
+                @endphp
+
+                <li @maryClass(['menu-disabled' => $disabled])>
                     <a
                         {{
-                            $attributes->class([
-                                "my-0.5 py-1.5 px-4 hover:text-inherit whitespace-nowrap",
-                                "mary-active-menu $activeBgColor" => ($active || ($activateByRoute && $routeMatches()))
-                            ])
+                            $attributes->class(
+                                Mary::classes('my-0.5 py-1.5 px-4 hover:text-inherit whitespace-nowrap')
+                                    ->add($isActive && is_null($activeBgColor) ? 'bg-base-300' : null)
+                                    ->addRaw(['mary-active-menu' => $isActive])
+                                    ->addRaw($isActive ? $activeBgColor : null)
+                            )
                         }}
 
                         @if($getHref())
@@ -110,22 +116,22 @@ class MenuItem extends Component
                     >
                         {{-- SPINNER --}}
                         @if($spinner)
-                            <span wire:loading wire:target="{{ $spinnerTarget() }}" class="loading loading-spinner loading-xs w-5 h-5 @if($icon) my-1 @endif"></span>
+                            <span wire:loading wire:target="{{ $spinnerTarget() }}" class="{{ Mary::classes(['loading loading-spinner loading-xs w-5 h-5', 'my-1' => $icon]) }}"></span>
                         @endif
 
                         @if($icon)
-                            <span class="block py-0.5" @if($spinner) wire:loading.class="hidden" wire:target="{{ $spinnerTarget() }}" @endif>
-                                <x-mary-icon :name="$icon" @class(['mb-0.5', $iconClasses]) />
+                            <span class="{{ Mary::classes('block py-0.5') }}" @if($spinner) wire:loading.class="{{ Mary::classes('hidden') }}" wire:target="{{ $spinnerTarget() }}" @endif>
+                                <x-mary-icon :name="$icon" class="{{ Mary::classes('mb-0.5')->addRaw($iconClasses) }}" />
                             </span>
                         @endif
 
                         @if($title || $slot->isNotEmpty())
-                        <span @class(["mary-hideable whitespace-nowrap", "truncate" => !$horizontal])>
+                        <span class="{{ Mary::classes(['whitespace-nowrap', 'truncate' => ! $horizontal])->addRaw('mary-hideable') }}">
                             @if($title)
                                 {{ $title }}
 
                                 @if($badge)
-                                    <span class="badge badge-sm {{ $badgeClasses }}">{{ $badge }}</span>
+                                    <span class="{{ Mary::classes('badge badge-sm')->addRaw($badgeClasses) }}">{{ $badge }}</span>
                                 @endif
                             @else
                                 {{ $slot }}

--- a/src/View/Components/MenuSeparator.php
+++ b/src/View/Components/MenuSeparator.php
@@ -16,20 +16,20 @@ class MenuSeparator extends Component
         public ?string $icon = null,
         public ?string $iconClasses = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
-                <hr class="my-3 border-t-[length:var(--border)] border-base-content/10"/>
+                <hr class="{{ Mary::classes('my-3 border-t-[length:var(--border)] border-base-content/10') }}"/>
 
                 @if($title)
-                    <li {{ $attributes->class(["menu-title text-inherit uppercase"]) }}>
-                        <div class="flex items-center gap-2">
+                    <li {{ $attributes->maryClass(["menu-title text-inherit uppercase"]) }}>
+                        <div class="{{ Mary::classes('flex items-center gap-2') }}">
 
                             @if($icon)
-                                <x-mary-icon :name="$icon" @class([$iconClasses]) />
+                                <x-mary-icon :name="$icon" class="{{ Mary::classes()->addRaw($iconClasses) }}" />
                             @endif
 
                             {{ $title }}

--- a/src/View/Components/MenuSub.php
+++ b/src/View/Components/MenuSub.php
@@ -19,7 +19,7 @@ class MenuSub extends Component
         public ?bool $hidden = false,
         public ?bool $disabled = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -29,7 +29,7 @@ class MenuSub extends Component
         }
 
         return <<<'BLADE'
-                @aware(['horizontal' => false, 'activeBgColor' => 'bg-base-300'])
+                @aware(['horizontal' => false, 'activeBgColor' => null])
 
                 @php
                     $submenuActive = Str::contains($slot, 'mary-active-menu');
@@ -37,7 +37,7 @@ class MenuSub extends Component
 
                 @if ($slot->isNotEmpty())
                 <li
-                @class(['menu-disabled' => $disabled, 'static!' => $horizontal])
+                @maryClass(['menu-disabled' => $disabled, 'static!' => $horizontal])
                     x-data="
                     {
                         show: @if(($submenuActive || $open) && !$horizontal) true @else false @endif,
@@ -61,17 +61,19 @@ class MenuSub extends Component
                     >
                         <summary
                             @click.prevent="toggle()"
-                            @class(["hover:text-inherit px-4 py-1.5 my-0.5 text-inherit", $activeBgColor => $submenuActive])
+                            class="{{ Mary::classes('hover:text-inherit px-4 py-1.5 my-0.5 text-inherit')
+                                ->add($submenuActive && is_null($activeBgColor) ? 'bg-base-300' : null)
+                                ->addRaw($submenuActive ? $activeBgColor : null) }}"
                             @if($horizontal) x-ref="sub" @endif
                         >
                             @if($icon)
-                                <x-mary-icon :name="$icon" @class(['inline-flex my-0.5', $iconClasses]) />
+                                <x-mary-icon :name="$icon" class="{{ Mary::classes('inline-flex my-0.5')->addRaw($iconClasses) }}" />
                             @endif
 
-                            <span class="mary-hideable whitespace-nowrap truncate">{{ $title }}</span>
+                            <span class="{{ Mary::classes('whitespace-nowrap truncate')->addRaw('mary-hideable') }}">{{ $title }}</span>
                         </summary>
 
-                        <ul @class(["mary-hideable",  "z-10 mt-1" => $horizontal]) @if($horizontal) x-anchor.bottom-start="$refs.sub" @endif>
+                        <ul class="{{ Mary::classes(['z-10 mt-1' => $horizontal])->addRaw('mary-hideable') }}" @if($horizontal) x-anchor.bottom-start="$refs.sub" @endif>
                             {{ $slot }}
                         </ul>
                     </details>

--- a/src/View/Components/MenuTitle.php
+++ b/src/View/Components/MenuTitle.php
@@ -16,17 +16,17 @@ class MenuTitle extends Component
         public ?string $icon = null,
         public ?string $iconClasses = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
-                <li {{ $attributes->class(["menu-title"]) }}>
-                    <div class="flex items-center gap-2">
+                <li {{ $attributes->maryClass(["menu-title"]) }}>
+                    <div class="{{ Mary::classes('flex items-center gap-2') }}">
 
                         @if($icon)
-                            <x-mary-icon :name="$icon" @class([$iconClasses]) />
+                            <x-mary-icon :name="$icon" class="{{ Mary::classes()->addRaw($iconClasses) }}" />
                         @endif
 
                         {{ $title }}

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -27,14 +27,14 @@ class Modal extends Component
     {
         return <<<'HTML'
                 <dialog
-                    {{ $attributes->except('wire:model')->class(["modal"]) }}
+                    {{ $attributes->except('wire:model')->maryClass(["modal"]) }}
 
                     @if($id)
                         id="{{ $id }}"
                     @else
                         x-data="{open: @entangle($attributes->wire('model')).live }"
                         x-init="$watch('open', value => { if (!value){ $dispatch('close') }else{ $dispatch('open') } })"
-                        :class="{'modal-open !animate-none': open}"
+                        :class="{'{{ Mary::classes('modal-open !animate-none') }}': open}"
                         :open="open"
                         @if(!$persistent)
                             @keydown.escape.window = "$wire.{{ $attributes->wire('model')->value() }} = false"
@@ -45,19 +45,19 @@ class Modal extends Component
                         x-trap="open" x-bind:inert="!open"
                     @endif
                 >
-                    <div class="modal-box {{ $boxClass }}">
+                    <div class="{{ Mary::classes('modal-box')->addRaw($boxClass) }}">
                         @if(!$persistent)
                             <form method="dialog" tabindex="-1">
                                 @if ($id)
-                                    <x-mary-button class="btn-circle btn-sm btn-ghost absolute end-2 top-2 z-[999]" icon="o-x-mark" type="submit" tabindex="-1" />
+                                    <x-mary-button class="{{ Mary::classes('btn-circle btn-sm btn-ghost absolute end-2 top-2 z-[999]') }}" icon="o-x-mark" type="submit" tabindex="-1" />
                                 @else
-                                    <x-mary-button class="btn-circle btn-sm btn-ghost absolute end-2 top-2 z-[999]" icon="o-x-mark" @click="$wire.{{ $attributes->wire('model')->value() }} = false" tabindex="-1" />
+                                    <x-mary-button class="{{ Mary::classes('btn-circle btn-sm btn-ghost absolute end-2 top-2 z-[999]') }}" icon="o-x-mark" @click="$wire.{{ $attributes->wire('model')->value() }} = false" tabindex="-1" />
                                 @endif
                             </form>
                         @endif
 
                         @if($title)
-                            <x-mary-header :title="$title" :subtitle="$subtitle" size="text-xl" :separator="$separator" class="!mb-5" />
+                            <x-mary-header :title="$title" :subtitle="$subtitle" size="text-xl" :separator="$separator" class="{{ Mary::classes('!mb-5') }}" />
                         @endif
 
                         <div>
@@ -65,18 +65,18 @@ class Modal extends Component
                         </div>
 
                         @if($separator && $actions)
-                            <hr class="border-t-[length:var(--border)] border-base-content/10 mt-5" />
+                            <hr class="{{ Mary::classes('border-t-[length:var(--border)] border-base-content/10 mt-5') }}" />
                         @endif
 
                         @if($actions)
-                            <div class="modal-action">
+                            <div class="{{ Mary::classes('modal-action') }}">
                                 {{ $actions }}
                             </div>
                         @endif
                     </div>
 
                     @if(!$persistent)
-                        <form class="modal-backdrop" method="dialog">
+                        <form class="{{ Mary::classes('modal-backdrop') }}" method="dialog">
                             @if ($id)
                                 <button type="submit">close</button>
                             @else

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -57,7 +57,7 @@ class Modal extends Component
                         @endif
 
                         @if($title)
-                            <x-mary-header :title="$title" :subtitle="$subtitle" size="text-xl" :separator="$separator" class="{{ Mary::classes('!mb-5') }}" />
+                            <x-mary-header :title="$title" :subtitle="$subtitle" size="{{ Mary::classes('text-xl') }}" :separator="$separator" class="{{ Mary::classes('!mb-5') }}" />
                         @endif
 
                         <div>

--- a/src/View/Components/Nav.php
+++ b/src/View/Components/Nav.php
@@ -22,12 +22,12 @@ class Nav extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                    <div {{ $attributes->class(["bg-base-100 border-base-content/10 border-b-[length:var(--border)]", "sticky top-0 z-10" => $sticky]) }}>
-                        <div @class(["flex items-center px-6 py-3",  "max-w-screen-2xl mx-auto" => !$fullWidth])>
-                            <div {{ $brand?->attributes->class(["flex-1 flex items-center"]) }}>
+                    <div {{ $attributes->maryClass(["bg-base-100 border-base-content/10 border-b-[length:var(--border)]", "sticky top-0 z-10" => $sticky]) }}>
+                        <div @maryClass(["flex items-center px-6 py-3",  "max-w-screen-2xl mx-auto" => !$fullWidth])>
+                            <div {{ $brand?->attributes->maryClass(["flex-1 flex items-center"]) }}>
                                 {{ $brand }}
                             </div>
-                            <div {{ $actions?->attributes->class(["flex items-center gap-4"]) }}>
+                            <div {{ $actions?->attributes->maryClass(["flex items-center gap-4"]) }}>
                                 {{ $actions }}
                             </div>
                         </div>

--- a/src/View/Components/Pagination.php
+++ b/src/View/Components/Pagination.php
@@ -17,7 +17,7 @@ class Pagination extends Component
         public ?string $id = null,
         public ?array $perPageValues = [10, 20, 50, 100],
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -33,20 +33,20 @@ class Pagination extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-            <div class="mary-table-pagination">
-                <div {{ $attributes->class(["mb-4 border-t-[length:var(--border)] border-t-base-content/5"]) }}></div>
-                <div class="justify-between md:flex md:flex-row w-auto md:w-full items-center overflow-y-auto ps-2 pe-2 relative">
+            <div class="{{ Mary::classes()->addRaw('mary-table-pagination') }}">
+                <div {{ $attributes->maryClass(["mb-4 border-t-[length:var(--border)] border-t-base-content/5"]) }}></div>
+                <div class="{{ Mary::classes('justify-between md:flex md:flex-row w-auto md:w-full items-center overflow-y-auto ps-2 pe-2 relative') }}">
                     @if($isShowable())
-                    <div class="flex flex-row justify-center md:justify-start mb-2 md:mb-0 py-1">
+                    <div class="{{ Mary::classes('flex flex-row justify-center md:justify-start mb-2 md:mb-0 py-1') }}">
                         <select id="{{ $uuid }}" @if(!empty($modelName())) wire:model.live="{{ $modelName() }}" @endif
-                                class="select select-sm flex sm:text-sm sm:leading-6 w-auto md:mr-5">
+                                class="{{ Mary::classes('select select-sm flex sm:text-sm sm:leading-6 w-auto md:mr-5') }}">
                             @foreach ($perPageValues as $option)
                             <option value="{{ $option }}" @selected($rows->perPage() === $option)>{{ $option }}</option>
                             @endforeach
                         </select>
                     </div>
                     @endif
-                    <div class="w-full">
+                    <div class="{{ Mary::classes('w-full') }}">
                     @if($rows instanceof LengthAwarePaginator)
                         {{ $rows->onEachSide(1)->links(data: ['scrollTo' => false]) }}
                     @else

--- a/src/View/Components/Password.php
+++ b/src/View/Components/Password.php
@@ -17,13 +17,13 @@ class Password extends Component
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $prefix = null,
         public ?string $suffix = null,
         public ?bool $inline = false,
         public ?bool $clearable = false,
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
 
         // Password
         public ?string $passwordIcon = 'o-eye-slash',
@@ -38,20 +38,20 @@ class Password extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
 
         // Cannot use a left icon when password toggle should be shown on the left side.
         if (($this->icon && ! $this->right) && ! $this->onlyPassword) {
-            throw new Exception("Cannot use `icon` without providing `right` or `onlyPassword`.");
+            throw new Exception('Cannot use `icon` without providing `right` or `onlyPassword`.');
         }
 
         // Cannot use a right icon when password toggle should be shown on the right side.
         if (($this->iconRight && $this->right) && ! $this->onlyPassword) {
-            throw new Exception("Cannot use `iconRight` when providing `right` and not providing `onlyPassword`.");
+            throw new Exception('Cannot use `iconRight` when providing `right` and not providing `onlyPassword`.');
         }
     }
 
@@ -84,21 +84,21 @@ class Password extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger>
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content>
                                         {{ $popover }}
@@ -108,19 +108,19 @@ class Password extends Component
                         </legend>
                     @endif
 
-                    <div @class(["floating-label" => $label && $inline])>
+                    <div @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div @class(["w-full", "join" => $prepend || $append])>
+                        <div @maryClass(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}
@@ -131,7 +131,7 @@ class Password extends Component
                                 x-data="{ hidden: true }"
 
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "input w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -141,20 +141,20 @@ class Password extends Component
                              >
                                 {{-- PREFIX --}}
                                 @if($prefix)
-                                    <span class="label">{{ $prefix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                 @endif
 
                                 {{-- ICON LEFT / TOGGLE INPUT TYPE --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @elseif($placeToggleLeft())
                                     <x-mary-button
                                         x-on:click="hidden = !hidden"
-                                        class="btn-ghost btn-xs btn-circle -m-1"
+                                        class="{{ Mary::classes('btn-ghost btn-xs btn-circle -m-1') }}"
                                         :tabindex="$passwordIconTabindex ? null : -1"
                                     >
-                                        <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="w-4 h-4 opacity-40" />
-                                        <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="w-4 h-4 opacity-40" />
+                                        <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="{{ Mary::classes('w-4 h-4 opacity-40') }}" />
+                                        <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="{{ Mary::classes('w-4 h-4 opacity-40') }}" />
                                     </x-mary-button>
                                 @endif
 
@@ -173,26 +173,26 @@ class Password extends Component
 
                                 {{-- CLEAR ICON  --}}
                                 @if($clearable)
-                                    <x-mary-icon x-on:click="$wire.set('{{ $modelName() }}', '', {{ json_encode($attributes->wire('model')->hasModifier('live')) }})"  name="o-x-mark" class="cursor-pointer w-4 h-4 opacity-40"/>
+                                    <x-mary-icon x-on:click="$wire.set('{{ $modelName() }}', '', {{ json_encode($attributes->wire('model')->hasModifier('live')) }})"  name="o-x-mark" class="{{ Mary::classes('cursor-pointer w-4 h-4 opacity-40') }}"/>
                                 @endif
 
                                 {{-- ICON RIGHT / TOGGLE INPUT TYPE --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" @class(["pointer-events-none w-4 h-4 opacity-40", "!end-10" => $clearable]) />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes(['pointer-events-none w-4 h-4 opacity-40', '!end-10' => $clearable]) }}" />
                                 @elseif($placeToggleRight())
                                     <x-mary-button
                                         x-on:click="hidden = !hidden"
-                                        @class(["btn-ghost btn-xs btn-circle -m-1", "!end-9" => $clearable])
+                                        class="{{ Mary::classes(['btn-ghost btn-xs btn-circle -m-1', '!end-9' => $clearable]) }}"
                                         :tabindex="$passwordIconTabindex ? null : -1"
                                     >
-                                        <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="w-4 h-4 opacity-40" />
-                                        <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="w-4 h-4 opacity-40" />
+                                        <x-mary-icon name="{{ $passwordIcon }}" x-show="hidden" class="{{ Mary::classes('w-4 h-4 opacity-40') }}" />
+                                        <x-mary-icon name="{{ $passwordVisibleIcon }}" x-show="!hidden" x-cloak class="{{ Mary::classes('w-4 h-4 opacity-40') }}" />
                                     </x-mary-button>
                                 @endif
 
                                 {{-- SUFFIX --}}
                                 @if($suffix)
-                                    <span class="label">{{ $suffix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                 @endif
                             </div>
 
@@ -205,14 +205,14 @@ class Password extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
 
                     {{-- ERROR --}}
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)

--- a/src/View/Components/Pin.php
+++ b/src/View/Components/Pin.php
@@ -15,17 +15,17 @@ class Pin extends Component
         public ?string $id = null,
         public ?bool $numeric = false,
         public ?bool $hide = false,
-        public ?string $hideType = "disc",
+        public ?string $hideType = 'disc',
         public ?bool $noGap = false,
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error text-xs pt-2',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -90,7 +90,7 @@ class Pin extends Component
                         }"
                     >
                         <div
-                            @class(["flex", "join" => $noGap, "gap-3" => !$noGap])
+                            @maryClass(["flex", "join" => $noGap, "gap-3" => !$noGap])
                             id="pin{{ $uuid }}"
                         >
                             @foreach(range(0, $size - 1) as $i)
@@ -113,7 +113,7 @@ class Pin extends Component
                                         x-mask="9"
                                     @endif
                                     {{
-                                        $attributes->whereDoesntStartWith('wire')->class([
+                                        $attributes->whereDoesntStartWith('wire')->maryClass([
                                             "input input-border min-w-6 max-w-12 p-0 font-bold text-xl text-center",
                                             "join-item" => $noGap,
                                             "!input-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
@@ -127,7 +127,7 @@ class Pin extends Component
                         @if(!$omitError && $errors->has($errorFieldName()))
                             @foreach($errors->get($errorFieldName()) as $message)
                                 @foreach(Arr::wrap($message) as $line)
-                                    <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                    <div class="{{ is_null($errorClass) ? Mary::classes('text-error text-xs pt-2') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                     @break($firstErrorOnly)
                                 @endforeach
                                 @break($firstErrorOnly)

--- a/src/View/Components/Popover.php
+++ b/src/View/Components/Popover.php
@@ -12,15 +12,15 @@ class Popover extends Component
 
     public function __construct(
         public ?string $id = null,
-        public ?string $position = "bottom",
-        public ?string $offset = "10",
+        public ?string $position = 'bottom',
+        public ?string $offset = '10',
 
         // Slots
         public mixed $trigger = null,
         public mixed $content = null
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -45,7 +45,7 @@ class Popover extends Component
                     x-ref="myTrigger"
                     @mouseover="show()"
                     @mouseout="hide()"
-                    {{ $trigger->attributes->class(["w-fit cursor-pointer"]) }}
+                    {{ $trigger->attributes->maryClass(["w-fit cursor-pointer"]) }}
                   >
                     {{ $trigger }}
                   </div>
@@ -57,7 +57,7 @@ class Popover extends Component
                     x-transition
                     @mouseover="show()"
                     @mouseout="hide()"
-                    {{ $content->attributes->class(["z-[1] shadow-xl border-[length:var(--border)] border-base-content/10 w-fit p-3 rounded-md bg-base-100"]) }}
+                    {{ $content->attributes->maryClass(["z-[1] shadow-xl border-[length:var(--border)] border-base-content/10 w-fit p-3 rounded-md bg-base-100"]) }}
                   >
                     {{ $content }}
                   </div>

--- a/src/View/Components/Progress.php
+++ b/src/View/Components/Progress.php
@@ -16,14 +16,14 @@ class Progress extends Component
         public ?float $max = 100,
         public ?bool $indeterminate = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
     {
         return <<<'HTML'
                 <progress
-                    {{ $attributes->class("progress") }}
+                    {{ $attributes->class(Mary::classes("progress")) }}
 
                     @if(!$indeterminate)
                         value="{{ $value }}"

--- a/src/View/Components/ProgressRadial.php
+++ b/src/View/Components/ProgressRadial.php
@@ -15,7 +15,7 @@ class ProgressRadial extends Component
         public ?float $value = 0,
         public ?string $unit = '%'
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -24,7 +24,7 @@ class ProgressRadial extends Component
                  <div
                     {{
                         $attributes
-                            ->class("radial-progress")
+                            ->class(Mary::classes("radial-progress"))
                             ->style("--value: $value")
                     }}
 

--- a/src/View/Components/Radio.php
+++ b/src/View/Components/Radio.php
@@ -15,26 +15,26 @@ class Radio extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $optionValue = 'id',
         public ?string $optionLabel = 'name',
         public ?string $optionHint = 'hint',
         public Collection|array $options = new Collection(),
         public ?bool $inline = false,
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -51,21 +51,21 @@ class Radio extends Component
     {
         return <<<'BLADE'
                 <div>
-                    <fieldset class="fieldset py-0">
+                    <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label)
-                        <legend class="fieldset-legend mb-2">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-2') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
                             
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -75,10 +75,10 @@ class Radio extends Component
                         </legend>
                     @endif
 
-                        <div @class(["gap-4 grid", "sm:flex sm:gap-6" => $inline])>
+                        <div @maryClass(["gap-4 grid", "sm:flex sm:gap-6" => $inline])>
                             @foreach ($options as $option)
                                 <label>
-                                    <div @class(["flex items-center gap-3 cursor-pointer", "!items-start" => data_get($option, $optionHint)])>
+                                    <div @maryClass(["flex items-center gap-3 cursor-pointer", "!items-start" => data_get($option, $optionHint)])>
                                         <input
                                             type="radio"
                                             name="{{ $modelName() }}"
@@ -86,18 +86,18 @@ class Radio extends Component
                                             @if(data_get($option, 'disabled')) disabled @endif
 
                                             {{ $attributes->whereStartsWith('wire:model') }}
-                                            {{ $attributes->class(["radio"]) }}
+                                            {{ $attributes->maryClass(["radio"]) }}
                                         />
 
                                         <div>
                                             {{-- NAME --}}
-                                            <div class="text-sm font-medium">
+                                            <div class="{{ Mary::classes('text-sm font-medium') }}">
                                                 {{ data_get($option, $optionLabel) }}
                                             </div>
 
                                             {{-- HINT --}}
                                             @if(data_get($option, $optionHint))
-                                                <div class="{{ $hintClass }} mt-1" x-classes="fieldset-label">
+                                                <div class="{{ Mary::classes('mt-1')->add(is_null($hintClass) ? 'fieldset-label' : null)->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">
                                                     {{ data_get($option, $optionHint) }}
                                                 </div>
                                             @endif
@@ -111,7 +111,7 @@ class Radio extends Component
                         @if(!$omitError && $errors->has($errorFieldName()))
                             @foreach($errors->get($errorFieldName()) as $message)
                                 @foreach(Arr::wrap($message) as $line)
-                                    <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                    <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                     @break($firstErrorOnly)
                                 @endforeach
                                 @break($firstErrorOnly)
@@ -120,7 +120,7 @@ class Radio extends Component
 
                         {{-- HINT --}}
                         @if($hint)
-                            <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                            <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                         @endif
                 </fieldset>
             </div>

--- a/src/View/Components/Range.php
+++ b/src/View/Components/Range.php
@@ -14,23 +14,23 @@ class Range extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?int $min = 0,
         public ?int $max = 100,
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -47,21 +47,21 @@ class Range extends Component
     {
         return <<<'BLADE'
             <div>
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
                             
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -76,14 +76,14 @@ class Range extends Component
                         type="range"
                         min="{{ $min }}"
                         max="{{ $max }}"
-                        {{ $attributes->merge(["class" => "range w-full", "id" => $uuid])->except('label', 'hint', 'min', 'max') }}
+                        {{ $attributes->class(Mary::classes('range w-full'))->merge(["id" => $uuid])->except('label', 'hint', 'min', 'max') }}
                     />
 
                     {{-- ERROR --}}
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -92,7 +92,7 @@ class Range extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/Rating.php
+++ b/src/View/Components/Rating.php
@@ -14,7 +14,7 @@ class Rating extends Component
         public ?string $id = null,
         public int $total = 5
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -30,13 +30,13 @@ class Rating extends Component
     public function render(): View|Closure|string
     {
         return <<<'HTML'
-                <div class="rating gap-1 {{ $size }}" x-cloak>
+                <div class="{{ Mary::classes('rating gap-1')->addRaw($size) }}" x-cloak>
                     <!-- NO RATING-->
                     <input
                         type="radio"
                         name="{{ $modelName() }}"
                         value="0"
-                        class="rating-hidden hidden"
+                        class="{{ Mary::classes('rating-hidden hidden') }}"
                         {{ $attributes->whereStartsWith('wire:model') }}
                     />
 
@@ -46,7 +46,7 @@ class Rating extends Component
                             name="{{ $modelName() }}"
                             value="{{ $i }}"
                             {{ $attributes->whereStartsWith('wire:model') }}
-                            {{ $attributes->class(["mask mask-star-2"]) }}
+                            {{ $attributes->maryClass(["mask mask-star-2"]) }}
                         />
                     @endfor
                 </div>

--- a/src/View/Components/Select.php
+++ b/src/View/Components/Select.php
@@ -17,7 +17,7 @@ class Select extends Component
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $prefix = null,
         public ?string $suffix = null,
         public ?string $placeholder = null,
@@ -27,9 +27,9 @@ class Select extends Component
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
@@ -39,11 +39,11 @@ class Select extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -65,21 +65,21 @@ class Select extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -89,19 +89,19 @@ class Select extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div @class(["w-full", "join" => $prepend || $append])>
+                        <div @maryClass(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}
@@ -110,7 +110,7 @@ class Select extends Component
                             {{-- THE LABEL THAT HOLDS THE INPUT --}}
                             <label
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "select w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -121,12 +121,12 @@ class Select extends Component
 
                                 {{-- PREFIX --}}
                                 @if($prefix)
-                                    <span class="label">{{ $prefix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                 @endif
 
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 -ms-1 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 -ms-1 opacity-40') }}" />
                                 @endif
 
                                 {{-- SELECT --}}
@@ -142,12 +142,12 @@ class Select extends Component
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
 
                                 {{-- SUFFIX --}}
                                 @if($suffix)
-                                    <span class="label">{{ $suffix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                 @endif
                             </label>
 
@@ -162,7 +162,7 @@ class Select extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -171,7 +171,7 @@ class Select extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/SelectGroup.php
+++ b/src/View/Components/SelectGroup.php
@@ -17,7 +17,7 @@ class SelectGroup extends Component
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $placeholder = null,
         public ?string $placeholderValue = null,
         public ?bool $inline = false,
@@ -25,9 +25,9 @@ class SelectGroup extends Component
         public ?string $optionLabel = 'name',
         public Collection|array $options = new Collection(),
 
-	    // Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
@@ -37,11 +37,11 @@ class SelectGroup extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -63,21 +63,21 @@ class SelectGroup extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -87,19 +87,19 @@ class SelectGroup extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div @class(["w-full", "join" => $prepend || $append])>
+                        <div @maryClass(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}
@@ -108,7 +108,7 @@ class SelectGroup extends Component
                             {{-- THE LABEL THAT HOLDS THE INPUT --}}
                             <label
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "select w-full",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -119,7 +119,7 @@ class SelectGroup extends Component
 
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 -ms-1 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 -ms-1 opacity-40') }}" />
                                 @endif
 
                                 {{-- SELECT --}}
@@ -138,7 +138,7 @@ class SelectGroup extends Component
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
                             </label>
 
@@ -151,14 +151,14 @@ class SelectGroup extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
 
                     {{-- ERROR --}}
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)

--- a/src/View/Components/Signature.php
+++ b/src/View/Components/Signature.php
@@ -15,17 +15,17 @@ class Signature extends Component
         public ?string $height = '250',
         public ?string $clearText = 'Clear',
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label text-xs pt-1',
+        public ?string $hintClass = null,
         public ?array $config = [],
         public ?string $clearBtnStyle = null,
 
         // Validations
-        public ?string $errorClass = 'text-error text-xs pt-1',
+        public ?string $errorClass = null,
         public ?string $errorField = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -75,23 +75,23 @@ class Signature extends Component
                          }"
 
                          wire:ignore
-                         class="select-none touch-none block"
+                         class="{{ Mary::classes('select-none touch-none block') }}"
                     >
                         <div
                             {{
                                 $attributes
                                     ->except("wire:model")
-                                    ->class([
+                                    ->maryClass([
                                         "border-[length:var(--border)] border-base-300 rounded-lg relative bg-white select-none touch-none block",
                                         "!border-error" => $errors->has($modelName())
                                     ])
                             }}
                         }>
-                            <canvas id="{{ $uuid }}signature" height="{{ $height }}" class="rounded-lg block w-full select-none touch-none"></canvas>
+                            <canvas id="{{ $uuid }}signature" height="{{ $height }}" class="{{ Mary::classes('rounded-lg block w-full select-none touch-none') }}"></canvas>
 
                             <!-- CLEAR BUTTON -->
-                            <div class="absolute end-2 top-1/2 -translate-y-1/2 ">
-                                <x-mary-button icon="o-backspace" :label="$clearText" @click="clear" class="{{$clearBtnStyle ?? 'btn-sm btn-ghost'}}" />
+                            <div class="{{ Mary::classes('absolute end-2 top-1/2 -translate-y-1/2 ') }}">
+                                <x-mary-button icon="o-backspace" :label="$clearText" @click="clear" class="{{ is_null($clearBtnStyle) ? Mary::classes('btn-sm btn-ghost') : Mary::classes()->addRaw($clearBtnStyle) }}" />
                             </div>
                         </div>
                     </div>
@@ -100,7 +100,7 @@ class Signature extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-classes="text-error text-xs pt-1">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error text-xs pt-1') : Mary::classes()->addRaw($errorClass) }}" x-classes="{{ Mary::classes('text-error text-xs pt-1') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -109,7 +109,7 @@ class Signature extends Component
 
                     <!-- HINT -->
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label text-xs pt-1">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label text-xs pt-1') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label text-xs pt-1') }}">{{ $hint }}</div>
                     @endif
                 </div>
             HTML;

--- a/src/View/Components/Spotlight.php
+++ b/src/View/Components/Spotlight.php
@@ -12,10 +12,10 @@ class Spotlight extends Component
 
     public function __construct(
         public ?string $id = null,
-        public ?string $shortcut = "meta.g",
-        public ?string $alternativeShortcut = "ctrl.g",
-        public ?string $searchText = "Search ...",
-        public ?string $noResultsText = "Nothing found.",
+        public ?string $shortcut = 'meta.g',
+        public ?string $alternativeShortcut = 'ctrl.g',
+        public ?string $searchText = 'Search ...',
+        public ?string $noResultsText = 'Nothing found.',
         public ?string $url = null,
         public ?string $fallbackAvatar = null,
         public ?bool $noWireNavigate = false,
@@ -23,7 +23,7 @@ class Spotlight extends Component
         // Slots
         public mixed $append = null
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
         $this->url = $this->url ?? route('mary.spotlight', absolute: false);
     }
 
@@ -128,22 +128,22 @@ class Spotlight extends Component
                     <x-mary-modal
                         id="marySpotlight"
                         x-ref="marySpotlightRef"
-                        class="backdrop-blur-sm"
-                        box-class="absolute py-0 top-0 lg:top-10 w-full lg:max-w-3xl rounded-none md:rounded-box"
+                        class="{{ Mary::classes('backdrop-blur-sm') }}"
+                        box-class="{{ Mary::classes('absolute py-0 top-0 lg:top-10 w-full lg:max-w-3xl rounded-none md:rounded-box') }}"
                     >
                         <div  @click.outside="close()">
                             <!-- INPUT -->
-                            <div class="flex">
-                                <div class="flex-1">
-                                    <div class="flex items-center">
-                                        <x-mary-icon name="o-magnifying-glass"  class="opacity-40" />
+                            <div class="{{ Mary::classes('flex') }}">
+                                <div class="{{ Mary::classes('flex-1') }}">
+                                    <div class="{{ Mary::classes('flex items-center') }}">
+                                        <x-mary-icon name="o-magnifying-glass"  class="{{ Mary::classes('opacity-40') }}" />
                                         <input
                                             id="{{ $uuid }}"
                                             x-model="value"
                                             x-ref="spotSearch"
                                             name="spotSearch"
                                             placeholder=" {{ $searchText }}"
-                                            class="w-full input my-2 border-none outline-none shadow-none border-transparent  focus:shadow-none focus:outline-none focus:border-transparent"
+                                            class="{{ Mary::classes('w-full input my-2 border-none outline-none shadow-none border-transparent  focus:shadow-none focus:outline-none focus:border-transparent') }}"
                                             @focus="$el.focus()"
                                             autofocus
                                             tabindex="1"
@@ -157,8 +157,8 @@ class Spotlight extends Component
                             </div>
 
                             <!-- PROGRESS  -->
-                            <div class="h-[1px]">
-                                <progress class="progress hidden h-[1px]" :class="elapsed > elapsedMax && '!h-[2px] !block'"></progress>
+                            <div class="{{ Mary::classes('h-[1px]') }}">
+                                <progress class="{{ Mary::classes('progress hidden h-[1px]') }}" :class="elapsed > elapsedMax && '{{ Mary::classes('!h-[2px] !block') }}'"></progress>
                             </div>
 
                             <!-- SLOT -->
@@ -168,16 +168,16 @@ class Spotlight extends Component
 
                             <!-- NO RESULTS -->
                             <template x-if="searchedWithNoResults && value != ''">
-                                <div class="text-base-content/50 p-3 border-t-[length:var(--border)] border-t-base-content/10 mary-spotlight-element">{{ $noResultsText }}</div>
+                                <div class="{{ Mary::classes('text-base-content/50 p-3 border-t-[length:var(--border)] border-t-base-content/10')->addRaw('mary-spotlight-element') }}">{{ $noResultsText }}</div>
                             </template>
 
                             <!-- RESULTS  -->
-                            <div class="-mx-1 mt-1" @click="close()" @keydown.enter="close()" x-ref="spotResults">
+                            <div class="{{ Mary::classes('-mx-1 mt-1') }}" @click="close()" @keydown.enter="close()" x-ref="spotResults">
                                 <template x-for="(item, index) in results" :key="index">
                                     <!-- ITEM -->
-                                    <a x-bind:href="item.link" class="mary-spotlight-element" @if(!$noWireNavigate) wire:navigate @endif tabindex="0">
-                                        <div class="p-3 hover:bg-base-200 border-t-[length:var(--border)] border-t-base-content/10" >
-                                            <div class="flex gap-3 items-center">
+                                    <a x-bind:href="item.link" class="{{ Mary::classes()->addRaw('mary-spotlight-element') }}" @if(!$noWireNavigate) wire:navigate @endif tabindex="0">
+                                        <div class="{{ Mary::classes('p-3 hover:bg-base-200 border-t-[length:var(--border)] border-t-base-content/10') }}" >
+                                            <div class="{{ Mary::classes('flex gap-3 items-center') }}">
                                                 <!-- ICON -->
                                                 <template x-if="item.icon">
                                                     <div x-html="item.icon"></div>
@@ -185,23 +185,23 @@ class Spotlight extends Component
                                                 <!-- AVATAR -->
                                                 <template x-if="item.avatar && !item.icon">
                                                     <div>
-                                                        <img :src="item.avatar" class="rounded-full w-11 h-11" @if($fallbackAvatar) onerror="this.src='{{ $fallbackAvatar }}'" @endif />
+                                                        <img :src="item.avatar" class="{{ Mary::classes('rounded-full w-11 h-11') }}" @if($fallbackAvatar) onerror="this.src='{{ $fallbackAvatar }}'" @endif />
                                                     </div>
                                                 </template>
-                                                <div class="flex-1 overflow-hidden whitespace-nowrap text-ellipsis truncate w-0 mary-hideable">
+                                                <div class="{{ Mary::classes('flex-1 overflow-hidden whitespace-nowrap text-ellipsis truncate w-0')->addRaw('mary-hideable') }}">
                                                     <!-- NAME -->
-                                                    <div x-html="item.name" class="font-semibold truncate"></div>
+                                                    <div x-html="item.name" class="{{ Mary::classes('font-semibold truncate') }}"></div>
 
                                                     <!-- DESCRIPTION -->
                                                     <template x-if="item.description">
-                                                        <div x-html="item.description" class="text-base-content/50 text-sm truncate"></div>
+                                                        <div x-html="item.description" class="{{ Mary::classes('text-base-content/50 text-sm truncate') }}"></div>
                                                     </template>
                                                 </div>
                                             </div>
                                         </div>
                                     </a>
                                 </template>
-                                <div x-show="results.length" class="mb-3"></div>
+                                <div x-show="results.length" class="{{ Mary::classes('mb-3') }}"></div>
                             </div>
                         </div>
                     </x-modal>

--- a/src/View/Components/Stat.php
+++ b/src/View/Components/Stat.php
@@ -25,7 +25,7 @@ class Stat extends Component
         public ?string $tooltipBottom = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
         $this->tooltip = $this->tooltip ?? $this->tooltipLeft ?? $this->tooltipRight ?? $this->tooltipBottom;
         $this->tooltipPosition = $this->tooltipLeft ? 'lg:tooltip-left' : ($this->tooltipRight ? 'lg:tooltip-right' : ($this->tooltipBottom ? 'lg:tooltip-bottom' : 'lg:tooltip-top'));
     }
@@ -34,28 +34,28 @@ class Stat extends Component
     {
         return <<<'HTML'
                 <div
-                    {{ $attributes->class(["bg-base-100 rounded-lg px-5 py-4  w-full", "lg:tooltip $tooltipPosition" => $tooltip]) }}
+                    {{ $attributes->maryClass(["bg-base-100 rounded-lg px-5 py-4  w-full", "lg:tooltip $tooltipPosition" => $tooltip]) }}
 
                     @if($tooltip)
                         data-tip="{{ $tooltip }}"
                     @endif
                 >
-                    <div class="flex items-center gap-3">
+                    <div class="{{ Mary::classes('flex items-center gap-3') }}">
                         @if($icon)
-                            <div class="  {{ $color }}">
-                                <x-mary-icon :name="$icon" class="w-9 h-9" />
+                            <div class="{{ Mary::classes()->addRaw($color) }}">
+                                <x-mary-icon :name="$icon" class="{{ Mary::classes('w-9 h-9') }}" />
                             </div>
                         @endif
 
-                        <div class="text-left rtl:text-right truncate">
+                        <div class="{{ Mary::classes('text-left rtl:text-right truncate') }}">
                             @if($title)
-                                <div class="text-xs text-base-content/50 whitespace-nowrap">{{ $title }}</div>
+                                <div class="{{ Mary::classes('text-xs text-base-content/50 whitespace-nowrap') }}">{{ $title }}</div>
                             @endif
 
-                            <div class="font-black text-xl">{{ $value ?? $slot }}</div>
+                            <div class="{{ Mary::classes('font-black text-xl') }}">{{ $value ?? $slot }}</div>
 
                             @if($description)
-                                <div class="stat-desc">{{ $description }}</div>
+                                <div class="{{ Mary::classes('stat-desc') }}">{{ $description }}</div>
                             @endif
                         </div>
                     </div>

--- a/src/View/Components/Step.php
+++ b/src/View/Components/Step.php
@@ -20,23 +20,25 @@ class Step extends Component
         public ?string $dataContent = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function iconHTML(): ?string
     {
-        return Blade::render("<x-mary-icon name='" . $this->icon . "' class='w-4 w-4' />");
+        $classes = app('mary')->classes('w-4 w-4');
+
+        return Blade::render("<x-mary-icon name='" . $this->icon . "' class='{$classes}' />");
     }
 
     public function render(): View|Closure|string
     {
         return <<<'BLADE'
                     <div
-                        class="hidden"
+                        class="{{ Mary::classes('hidden') }}"
                         x-init="steps.push({ step: '{{ $step }}', text: '{{ $text }}', classes: '{{ $stepClasses }}' @if($icon) , icon: {{ json_encode($iconHTML()) }}  @endif @if($dataContent), dataContent: '{{ $dataContent }}' @endif })"
                     ></div>
 
-                    <div x-show="current == '{{ $step }}'" {{ $attributes->class("px-1") }} >
+                    <div x-show="current == '{{ $step }}'" {{ $attributes->class(Mary::classes("px-1")) }} >
                         {{ $slot }}
                     </div>
             BLADE;

--- a/src/View/Components/Steps.php
+++ b/src/View/Components/Steps.php
@@ -13,11 +13,11 @@ class Steps extends Component
     public function __construct(
         public ?string $id = null,
         public bool $vertical = false,
-        public ?string $stepsColor = 'step-neutral',
+        public ?string $stepsColor = null,
         public ?string $stepperClasses = null
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -30,21 +30,21 @@ class Steps extends Component
                                 init() {
                                     // Fix weird issue when navigating back
                                     document.addEventListener('livewire:navigating', () => {
-                                        document.querySelectorAll('.step').forEach(el =>  el.remove());
+                                        document.querySelectorAll('.' + CSS.escape('{{ Mary::classes('step') }}')).forEach(el => el.remove());
                                     });
                                 }
                         }"
                     >
                         <!-- STEP LABELS -->
-                        <ul class="steps [&>*:nth-child(2)]:before:hidden {{ $stepperClasses }}">
+                        <ul class="{{ Mary::classes('steps [&>*:nth-child(2)]:before:hidden')->addRaw($stepperClasses) }}">
                             <template x-for="(step, index) in steps" :key="index">
                                 <li
-                                    class="step"
+                                    class="{{ Mary::classes('step') }}"
                                     :data-content="!step.icon ? step.dataContent || (index + 1) : ''"
-                                    :class="(index + 1 <= current) && '{{ $stepsColor }} ' + step.classes"
+                                    :class="(index + 1 <= current) && '{{ is_null($stepsColor) ? Mary::classes('step-neutral') : Mary::classes()->addRaw($stepsColor) }} ' + step.classes"
                                 >
                                         <template x-if="step.icon">
-                                            <span x-html="step.icon" class="step-icon"></span>
+                                            <span x-html="step.icon" class="{{ Mary::classes('step-icon') }}"></span>
                                         </template>
                                         <span x-html="step.text"></span>
                                 </li>
@@ -57,7 +57,7 @@ class Steps extends Component
                         </div>
 
                         <!-- Force Tailwind compile steps color -->
-                        <span class="hidden step-primary step-error step-success step-neutral step-info step-accent"></span>
+                        <span class="{{ Mary::classes('hidden step-primary step-error step-success step-neutral step-info step-accent') }}"></span>
                     </div>
             BLADE;
     }

--- a/src/View/Components/Swap.php
+++ b/src/View/Components/Swap.php
@@ -16,9 +16,9 @@ class Swap extends Component
         public ?string $false = null,
         public ?string $trueIcon = 'o-sun',
         public ?string $falseIcon = 'o-moon',
-        public ?string $iconSize = "h-5 w-5",
+        public ?string $iconSize = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -35,27 +35,27 @@ class Swap extends Component
                         </div>
                     @endif
 
-                    <div class="swap">
+                    <div class="{{ Mary::classes('swap') }}">
 
                         {{-- Hidden checkbox for state --}}
                         <input id="{{ $uuid }}" type="checkbox" {{ $attributes->wire('model') }} />
 
                         {{-- True Element --}}
                         @isset ($true)
-                            <div {{ is_string($true) ? new Illuminate\View\ComponentAttributeBag(['class' => 'swap-on']) : $true->attributes->merge(['class' => 'swap-on']) }}>
+                            <div {{ is_string($true) ? new Illuminate\View\ComponentAttributeBag(['class' => Mary::classes('swap-on')]) : $true->attributes->class(Mary::classes('swap-on')) }}>
                                 {{ $true ?? '' }}
                             </div>
                         @else
-                            <x-mary-icon :name="$trueIcon" class="swap-on {{ $iconSize }}" />
+                            <x-mary-icon :name="$trueIcon" class="{{ Mary::classes('swap-on')->add(is_null($iconSize) ? 'h-5 w-5' : null)->addRaw($iconSize) }}" />
                         @endif
 
                         {{-- False Element --}}
                         @isset ($false)
-                        <div {{ is_string($false) ? new Illuminate\View\ComponentAttributeBag(['class' => 'swap-off']) : $false->attributes->merge(['class' => 'swap-off']) }}>
+                        <div {{ is_string($false) ? new Illuminate\View\ComponentAttributeBag(['class' => Mary::classes('swap-off')]) : $false->attributes->class(Mary::classes('swap-off')) }}>
                                 {{ $false ?? '' }}
                             </div>
                         @else 
-                            <x-mary-icon :name="$falseIcon" class="swap-off {{ $iconSize }}" />
+                            <x-mary-icon :name="$falseIcon" class="{{ Mary::classes('swap-off')->add(is_null($iconSize) ? 'h-5 w-5' : null)->addRaw($iconSize) }}" />
                         @endif
 
                     </div>

--- a/src/View/Components/Tab.php
+++ b/src/View/Components/Tab.php
@@ -8,8 +8,6 @@ use Illuminate\View\Component;
 
 class Tab extends Component
 {
-
-
     public function __construct(
         public ?string $id = null,
         public ?string $name = null,
@@ -19,9 +17,7 @@ class Tab extends Component
         public bool $hidden = false,
         public ?string $badge = null,
         public ?string $badgeClass = null,
-    ) {
-
-    }
+    ) {}
 
     public function render(): View|Closure|string
     {
@@ -32,13 +28,12 @@ class Tab extends Component
                        <div wire:key="{{ $uuid() }}-tab-{{ $name }}">
                             <template x-teleport="#{{ $uuid() }}-labels">
                                 <label
-                                    @class([
-                                        "tab flex flex-nowrap items-center gap-3 whitespace-nowrap px-4",
-                                        $labelClass,
-                                        "hidden" => $hidden,
-                                        "tab-disabled" => $disabled
-                                     ])
-                                    :class="{ 'tab-active {{ $activeClass }}': selected === '{{ $name }}' }"
+                                    class="{{ Mary::classes([
+                                        'tab flex flex-nowrap items-center gap-3 whitespace-nowrap px-4',
+                                        'hidden' => $hidden,
+                                        'tab-disabled' => $disabled,
+                                    ])->addRaw($labelClass) }}"
+                                    :class="{ '{{ Mary::classes('tab-active')->addRaw($activeClass) }}': selected === '{{ $name }}' }"
                                     @click="selected = '{{ $name }}'"
                                 >
 
@@ -49,14 +44,14 @@ class Tab extends Component
                                     {{ $label }}
 
                                     @if ($badge)
-                                        <x-mary-badge :value="$badge" @class(["badge-sm badge-soft", $badgeClass]) />
+                                        <x-mary-badge :value="$badge" class="{{ Mary::classes('badge-sm badge-soft')->addRaw($badgeClass) }}" />
                                     @endif
                                 </label>
                             </template>
                         </div>
                         <div
                             x-show="selected == '{{ $name }}'"
-                            {{ $attributes->class(["tab-content py-5 px-3 border-t-base-content/10 block rounded-none", $contentClass]) }}
+                            {{ $attributes->class(Mary::classes('tab-content py-5 px-3 border-t-base-content/10 block rounded-none')->addRaw($contentClass)) }}
                          >
                             {{ $slot }}
                         </div>

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -38,7 +38,7 @@ class Table extends Component
         public ?array $cellDecoration = [],
         public ?bool $showEmptyText = false,
         public mixed $emptyText = 'No records found.',
-        public string $containerClass = 'overflow-x-auto',
+        public ?string $containerClass = null,
         public ?bool $noHover = false,
         public ?bool $fluent = false,
 
@@ -52,7 +52,7 @@ class Table extends Component
 
     ) {
         if ($this->selectable && $this->expandable) {
-            throw new Exception("You can not combine `expandable` with `selectable`.");
+            throw new Exception('You can not combine `expandable` with `selectable`.');
         }
 
         // Temp
@@ -66,7 +66,7 @@ class Table extends Component
         unset($this->headers);
 
         // Serialize
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
 
         // Put them back
         $this->rowDecoration = $rowDecoration;
@@ -167,7 +167,7 @@ class Table extends Component
 
         // Replace tokens by actual row values
         $tokens->each(function (string $token) use ($row, &$link) {
-            $link = Str::of($link)->replace("{" . $token . "}", data_get($row, $token))->toString();
+            $link = Str::of($link)->replace('{' . $token . '}', data_get($row, $token))->toString();
         });
 
         return $link;
@@ -201,7 +201,7 @@ class Table extends Component
 
     public function selectableModifier(): string
     {
-        return is_string($this->getAllIds()[0] ?? null) ? "" : ".number";
+        return is_string($this->getAllIds()[0] ?? null) ? '' : '.number';
     }
 
     public function getKeyValue($row, $key): mixed
@@ -263,12 +263,12 @@ class Table extends Component
                                 }
                              }"
                 >
-                <div class="{{ $containerClass }}" x-classes="overflow-x-auto">
+                <div class="{{ is_null($containerClass) ? Mary::classes('overflow-x-auto') : Mary::classes()->addRaw($containerClass) }}" x-classes="{{ Mary::classes('overflow-x-auto') }}">
                 <table
                         {{
                             $attributes
                                 ->whereDoesntStartWith('wire:model')
-                                ->class([
+                                ->maryClass([
                                     'table',
                                     'table-zebra' => $striped,
                                     '[&_tr:nth-child(4n+3)]:bg-base-200' => $striped && $expandable,
@@ -277,15 +277,15 @@ class Table extends Component
                         }}
                     >
                         <!-- HEADERS -->
-                        <thead @class(["text-base-content", "hidden" => $noHeaders])>
+                        <thead @maryClass(["text-base-content", "hidden" => $noHeaders])>
                             <tr x-ref="headers">
                                 <!-- CHECKALL -->
                                 @if($selectable)
-                                    <th class="w-1" wire:key="{{ $uuid }}-checkall-{{ implode(',', $getAllIds()) }}">
+                                    <th class="{{ Mary::classes('w-1') }}" wire:key="{{ $uuid }}-checkall-{{ implode(',', $getAllIds()) }}">
                                         <input
                                             id="checkAll-{{ $uuid }}"
                                             type="checkbox"
-                                            class="checkbox checkbox-sm"
+                                            class="{{ Mary::classes('checkbox checkbox-sm') }}"
                                             x-ref="mainCheckbox"
                                             x-bind:disabled="pageIds.length === 0"
                                             @click="toggleCheckAll($el.checked)" />
@@ -294,7 +294,7 @@ class Table extends Component
 
                                 <!-- EXPAND EXTRA HEADER -->
                                 @if($expandable)
-                                    <th class="w-1"></th>
+                                    <th class="{{ Mary::classes('w-1') }}"></th>
                                  @endif
 
                                 @foreach($headers as $header)
@@ -308,7 +308,7 @@ class Table extends Component
                                     @endphp
 
                                     <th
-                                        class="@if($isSortable($header)) cursor-pointer hover:bg-base-200 @endif {{ $header['class'] ?? ' ' }}"
+                                        class="{{ Mary::classes(['cursor-pointer hover:bg-base-200' => $isSortable($header)])->addRaw($header['class'] ?? '') }}"
 
                                         @if($sortBy && $isSortable($header))
                                             @click="$wire.set('{{ $sortByProperty }}', {column: '{{ $getSort($header)['column'] }}', direction: '{{ $getSort($header)['direction'] }}' })"
@@ -317,14 +317,14 @@ class Table extends Component
                                         {{ isset(${"header_".$temp_key}) ? ${"header_".$temp_key}($header) : $header['label'] }}
 
                                         @if($isSortable($header))
-                                            <x-mary-icon :name="$isSortedBy($header) ? $getSort($header)['direction'] == 'asc' ? 'o-chevron-down' : 'o-chevron-up' : 'o-chevron-up-down'"  class="size-3! mb-1 ms-1" />
+                                            <x-mary-icon :name="$isSortedBy($header) ? $getSort($header)['direction'] == 'asc' ? 'o-chevron-down' : 'o-chevron-up' : 'o-chevron-up-down'"  class="{{ Mary::classes('size-3! mb-1 ms-1') }}" />
                                         @endif
                                     </th>
                                 @endforeach
 
                                 <!-- ACTIONS (Just a empty column) -->
                                 @if($actions)
-                                    <th class="w-1"></th>
+                                    <th class="{{ Mary::classes('w-1') }}"></th>
                                 @endif
                             </tr>
                         </thead>
@@ -334,18 +334,18 @@ class Table extends Component
                             @foreach($rows as $k => $row)
                                 <tr
                                     wire:key="{{ $uuid }}-{{ $k }}"
-                                    @class([$rowClasses($row), "hover:bg-base-200" => !$noHover])
+                                    class="{{ Mary::classes(['hover:bg-base-200' => ! $noHover])->addRaw($rowClasses($row)) }}"
                                     @if($attributes->has('@row-click'))
                                         @click="$dispatch('row-click', {{ json_encode($row) }});"
                                     @endif
                                 >
                                     <!-- CHECKBOX -->
                                     @if($selectable)
-                                        <td class="w-1">
+                                        <td class="{{ Mary::classes('w-1') }}">
                                             <input
                                                 id="checkbox-{{ $uuid }}-{{ $k }}"
                                                 type="checkbox"
-                                                class="checkbox checkbox-sm"
+                                                class="{{ Mary::classes('checkbox checkbox-sm') }}"
                                                 value="{{ data_get($row, $selectableKey) }}"
                                                 x-model{{ $selectableModifier() }}="selection"
                                                 @click.stop="toggleCheck($el.checked, {{ json_encode($row) }})" />
@@ -354,12 +354,12 @@ class Table extends Component
 
                                     <!-- EXPAND ICON -->
                                     @if($expandable)
-                                        <td class="w-1 pe-0 py-0">
+                                        <td class="{{ Mary::classes('w-1 pe-0 py-0') }}">
                                             @if(data_get($row, $expandableCondition))
                                                 <x-mary-icon
                                                     name="o-chevron-down"
-                                                    ::class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || 'ltr:-rotate-90 rtl:rotate-90 !text-current'"
-                                                    class="cursor-pointer p-2 w-8 h-8 bg-base-300 rounded-lg"
+                                                    ::class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || '{{ Mary::classes('ltr:-rotate-90 rtl:rotate-90 !text-current') }}'"
+                                                    class="{{ Mary::classes('cursor-pointer p-2 w-8 h-8 bg-base-300 rounded-lg') }}"
                                                     @click="toggleExpand({{ $getKeyValue($row, 'expandableKey') }});" />
                                             @endif
                                         </td>
@@ -378,9 +378,9 @@ class Table extends Component
 
                                         <!--  HAS CUSTOM SLOT ? -->
                                         @if(isset(${"cell_".$temp_key}))
-                                            <td @class([$cellClasses($row, $header), "p-0" => $hasLink($header)])>
+                                            <td class="{{ Mary::classes(['p-0' => $hasLink($header)])->addRaw($cellClasses($row, $header)) }}">
                                                 @if($hasLink($header))
-                                                    <a href="{{ $redirectLink($row) }}" wire:navigate class="block py-3 px-4">
+                                                    <a href="{{ $redirectLink($row) }}" wire:navigate class="{{ Mary::classes('block py-3 px-4') }}">
                                                 @endif
 
                                                 {{ ${"cell_".$temp_key}($fluent ? fluent($row) : $row) }}
@@ -390,9 +390,9 @@ class Table extends Component
                                                  @endif
                                             </td>
                                         @else
-                                            <td @class([$cellClasses($row, $header), "p-0" => $hasLink($header)])>
+                                            <td class="{{ Mary::classes(['p-0' => $hasLink($header)])->addRaw($cellClasses($row, $header)) }}">
                                                 @if($hasLink($header))
-                                                    <a href="{{ $redirectLink($row) }}" wire:navigate class="block py-3 px-4">
+                                                    <a href="{{ $redirectLink($row) }}" wire:navigate class="{{ Mary::classes('block py-3 px-4') }}">
                                                 @endif
 
                                                 {{ $format($row, data_get($row, $header['key']), $header) }}
@@ -406,13 +406,13 @@ class Table extends Component
 
                                     <!-- ACTIONS -->
                                     @if($actions)
-                                        <td class="text-right py-0">{{ $actions($row) }}</td>
+                                        <td class="{{ Mary::classes('text-right py-0') }}">{{ $actions($row) }}</td>
                                     @endif
                                 </tr>
 
                                 <!-- EXPANSION SLOT -->
                                 @if($expandable)
-                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="!bg-inherit" :class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || 'hidden'">
+                                    <tr wire:key="{{ $uuid }}-{{ $k }}--expand" class="{{ Mary::classes('!bg-inherit') }}" :class="isExpanded({{ $getKeyValue($row, 'expandableKey') }}) || '{{ Mary::classes('hidden') }}'">
                                         <td :colspan="colspanSize">
                                             {{ $expansion($fluent ? fluent($row) : $row) }}
                                         </td>
@@ -431,12 +431,12 @@ class Table extends Component
 
                     @if(count($rows) === 0)
                         @if($showEmptyText)
-                            <div class="text-center py-4 text-base-content/50">
+                            <div class="{{ Mary::classes('text-center py-4 text-base-content/50') }}">
                                 {{ $emptyText }}
                             </div>
                         @endif
                         @if($empty)
-                            <div class="text-center py-4 text-base-content/50">
+                            <div class="{{ Mary::classes('text-center py-4 text-base-content/50') }}">
                                 {{ $empty }}
                             </div>
                         @endif

--- a/src/View/Components/Tabs.php
+++ b/src/View/Components/Tabs.php
@@ -15,9 +15,9 @@ class Tabs extends Component
         public ?string $labelClass = null,
         public ?string $activeClass = null,
         public ?string $contentClass = null,
-        public string $tabsClass = 'scrollbar-none flex-nowrap overflow-x-auto',
+        public ?string $tabsClass = null,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function uuid(): string
@@ -30,10 +30,10 @@ class Tabs extends Component
         return <<<'HTML'
                     <div
                         x-data="{ selected: @entangle($attributes->wire('model')) }"
-                        x-class="scrollbar-none flex-nowrap overflow-x-auto"
+                        x-class="{{ Mary::classes('scrollbar-none flex-nowrap overflow-x-auto') }}"
                     >
                         <!-- TABS -->
-                         <div id="{{ $uuid() }}-labels" wire:ignore {{ $attributes->except(['wire:model', 'wire:model.live'])->class(["tabs tabs-border", $tabsClass]) }}></div>
+                         <div id="{{ $uuid() }}-labels" wire:ignore {{ $attributes->except(['wire:model', 'wire:model.live'])->class(Mary::classes('tabs tabs-border')->add(is_null($tabsClass) ? 'scrollbar-none flex-nowrap overflow-x-auto' : null)->addRaw($tabsClass)) }}></div>
 
                         <!-- ORIGINAL DATA -->
                          <div>

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -14,7 +14,7 @@ class Tags extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?string $icon = null,
         public ?string $iconRight = null,
         public ?bool $inline = false,
@@ -24,7 +24,7 @@ class Tags extends Component
 
         // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
@@ -34,11 +34,11 @@ class Tags extends Component
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -136,21 +136,21 @@ class Tags extends Component
                 }"
                 @keydown.escape="clear()"
             >
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -160,19 +160,19 @@ class Tags extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div @class(["w-full", "join" => $prepend || $append])>
+                        <div @maryClass(["w-full", "join" => $prepend || $append])>
                             {{-- PREPEND --}}
                             @if($prepend)
                                 {{ $prepend }}
@@ -187,7 +187,7 @@ class Tags extends Component
                                 @endif
 
                                 {{
-                                    $attributes->whereStartsWith('class')->class([
+                                    $attributes->whereStartsWith('class')->maryClass([
                                         "input w-full h-fit ps-2.5",
                                         "join-item" => $prepend || $append,
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
@@ -197,27 +197,27 @@ class Tags extends Component
                              >
                                 {{-- PREFIX --}}
                                 @if($prefix)
-                                    <span class="label">{{ $prefix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $prefix }}</span>
                                 @endif
 
                                 {{-- ICON LEFT --}}
                                 @if($icon)
-                                    <x-mary-icon :name="$icon" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$icon" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
 
-                                <div class="w-full py-1 min-h-9.5 content-center text-wrap">
+                                <div class="{{ Mary::classes('w-full py-1 min-h-9.5 content-center text-wrap') }}">
                                     {{-- TAGS --}}
                                     <span wire:key="tags-{{ $uuid }}">
                                         <template :key="index" x-for="(tag, index) in tags">
-                                            <span class="mary-tags-element cursor-pointer badge badge-soft m-0.5 !inline-block">
+                                            <span class="{{ Mary::classes('cursor-pointer badge badge-soft m-0.5 !inline-block')->addRaw('mary-tags-element') }}">
                                                 <span x-text="tag"></span>
-                                                <x-mary-icon @click="remove(index)" x-show="!isReadonly && !isDisabled" name="o-x-mark" class="w-4 h-4 mb-0.5 hover:text-error" />
+                                                <x-mary-icon @click="remove(index)" x-show="!isReadonly && !isDisabled" name="o-x-mark" class="{{ Mary::classes('w-4 h-4 mb-0.5 hover:text-error') }}" />
                                             </span>
                                         </template>
                                     </span>
 
                                     {{-- PLACEHOLDER --}}
-                                    <span :class="(focused || tags.length) && 'hidden'" class="text-base-content/40">
+                                    <span :class="(focused || tags.length) && '{{ Mary::classes('hidden') }}'" class="{{ Mary::classes('text-base-content/40') }}">
                                         {{ $attributes->get('placeholder') }}
                                     </span>
 
@@ -226,7 +226,7 @@ class Tags extends Component
                                         id="{{ $uuid }}"
                                         type="text"
                                         enterkeyhint="done"
-                                        class="w-1 !inline-block"
+                                        class="{{ Mary::classes('w-1 !inline-block') }}"
                                         x-ref="searchInput"
                                         :required="isRequired"
                                         :readonly="isReadonly"
@@ -242,17 +242,17 @@ class Tags extends Component
 
                                 {{-- CLEAR ICON  --}}
                                 @if($clearable && !$isReadonly() && !$isDisabled())
-                                    <x-mary-icon @click="clearAll()" x-show="tags.length" name="o-x-mark" class="cursor-pointer w-4 h-4 opacity-40"/>
+                                    <x-mary-icon @click="clearAll()" x-show="tags.length" name="o-x-mark" class="{{ Mary::classes('cursor-pointer w-4 h-4 opacity-40') }}"/>
                                 @endif
 
                                 {{-- ICON RIGHT --}}
                                 @if($iconRight)
-                                    <x-mary-icon :name="$iconRight" class="pointer-events-none w-4 h-4 opacity-40" />
+                                    <x-mary-icon :name="$iconRight" class="{{ Mary::classes('pointer-events-none w-4 h-4 opacity-40') }}" />
                                 @endif
 
                                 {{-- SUFFIX --}}
                                 @if($suffix)
-                                    <span class="label">{{ $suffix }}</span>
+                                    <span class="{{ Mary::classes('label') }}">{{ $suffix }}</span>
                                 @endif
                             </label>
 
@@ -267,7 +267,7 @@ class Tags extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -278,14 +278,14 @@ class Tags extends Component
                     @error($modelName().'.*')
                         @foreach ($errors->get($modelName().'.*') as $fieldErrors)
                             @foreach ($fieldErrors as $message)
-                                <div class="text-error" x-classes="text-error">{{ $message }}</div>
+                                <div class="{{ Mary::classes('text-error') }}" x-classes="{{ Mary::classes('text-error') }}">{{ $message }}</div>
                             @endforeach
                         @endforeach
                     @enderror
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/Textarea.php
+++ b/src/View/Components/Textarea.php
@@ -14,22 +14,22 @@ class Textarea extends Component
         public ?string $id = null,
         public ?string $label = null,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
         public ?bool $inline = false,
 
-		// Popover
+        // Popover
         public ?string $popover = null,
-        public ?string $popoverIcon = "o-question-mark-circle",
+        public ?string $popoverIcon = 'o-question-mark-circle',
         public ?string $popoverTriggerClass = '',
         public ?string $popoverContentClass = '',
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -51,21 +51,21 @@ class Textarea extends Component
                     $uuid = $uuid . $modelName()
                 @endphp
 
-                <fieldset class="fieldset py-0">
+                <fieldset class="{{ Mary::classes('fieldset py-0') }}">
                     {{-- STANDARD LABEL --}}
                     @if($label && !$inline)
-                        <legend class="fieldset-legend mb-0.5">
+                        <legend class="{{ Mary::classes('fieldset-legend mb-0.5') }}">
                             {{ $label }}
 
                             @if($attributes->get('required'))
-                                <span class="text-error">*</span>
+                                <span class="{{ Mary::classes('text-error') }}">*</span>
                             @endif
 
                             {{-- INPUT POPOVER --}}
                             @if($popover)
                                 <x-mary-popover offset="5" position="top-start">
                                     <x-slot:trigger class="{{ $popoverTriggerClass }}">
-                                        <x-mary-icon :name="$popoverIcon" class="w-4 h-4 opacity-40 mb-0.5" />
+                                        <x-mary-icon :name="$popoverIcon" class="{{ Mary::classes('w-4 h-4 opacity-40 mb-0.5') }}" />
                                     </x-slot:trigger>
                                     <x-slot:content class="{{ $popoverContentClass }}">
                                         {{ $popover }}
@@ -75,26 +75,26 @@ class Textarea extends Component
                         </legend>
                     @endif
 
-                    <label @class(["floating-label" => $label && $inline])>
+                    <label @maryClass(["floating-label" => $label && $inline])>
                         {{-- FLOATING LABEL--}}
                         @if ($label && $inline)
-                            <span class="font-semibold">
+                            <span class="{{ Mary::classes('font-semibold') }}">
                                 {{ $label }}
 
                                 @if($attributes->get('required'))
-                                    <span class="text-error">*</span>
+                                    <span class="{{ Mary::classes('text-error') }}">*</span>
                                 @endif
                             </span>
                         @endif
 
-                        <div class="w-full">
+                        <div class="{{ Mary::classes('w-full') }}">
                             {{-- TEXTAREA --}}
                             <textarea
                                 placeholder="{{ $attributes->get('placeholder') }} "
 
                                {{
                                     $attributes->merge(['id' => $uuid])
-                                    ->class([
+                                    ->maryClass([
                                         "textarea w-full",
                                         "border-dashed" => $attributes->has("readonly") && $attributes->get("readonly") == true,
                                         "!textarea-error" => $errorFieldName() && $errors->has($errorFieldName()) && !$omitError
@@ -108,7 +108,7 @@ class Textarea extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)
@@ -117,7 +117,7 @@ class Textarea extends Component
 
                     {{-- HINT --}}
                     @if($hint)
-                        <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                        <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                     @endif
                 </fieldset>
             </div>

--- a/src/View/Components/ThemeToggle.php
+++ b/src/View/Components/ThemeToggle.php
@@ -13,16 +13,16 @@ class ThemeToggle extends Component
     public function __construct(
         public ?string $id = null,
         public ?string $value = null,
-        public ?string $light = "Light",
-        public ?string $dark = "Dark",
-        public ?string $lightTheme = "light",
-        public ?string $darkTheme = "dark",
-        public ?string $lightClass = "light",
-        public ?string $darkClass = "dark",
+        public ?string $light = 'Light',
+        public ?string $dark = 'Dark',
+        public ?string $lightTheme = 'light',
+        public ?string $darkTheme = 'dark',
+        public ?string $lightClass = 'light',
+        public ?string $darkClass = 'dark',
         public ?bool $withLabel = false,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -36,10 +36,10 @@ class ThemeToggle extends Component
                             class: $persist(window.matchMedia('(prefers-color-scheme: dark)').matches ? '{{ $darkClass }}' : '{{ $lightClass }}').as('mary-class'),
                             init() {
                                 if (this.theme == '{{ $darkTheme }}') {
-                                    this.$refs.sun.classList.add('swap-off');
-                                    this.$refs.sun.classList.remove('swap-on');
-                                    this.$refs.moon.classList.add('swap-on');
-                                    this.$refs.moon.classList.remove('swap-off');
+                                    this.$refs.sun.classList.add('{{ Mary::classes('swap-off') }}');
+                                    this.$refs.sun.classList.remove('{{ Mary::classes('swap-on') }}');
+                                    this.$refs.moon.classList.add('{{ Mary::classes('swap-on') }}');
+                                    this.$refs.moon.classList.remove('{{ Mary::classes('swap-off') }}');
                                 }
                                 this.setToggle()
                             },
@@ -56,11 +56,11 @@ class ThemeToggle extends Component
                             }
                         }"
                         @mary-toggle-theme.window="toggle()"
-                        {{ $attributes->class("swap swap-rotate") }}
+                        {{ $attributes->class(Mary::classes("swap swap-rotate")) }}
                     >
-                        <input id="{{ $uuid }}" type="checkbox" class="theme-controller opacity-0" @click="toggle()" :value="theme" />
-                        <x-mary-icon x-ref="sun" name="o-sun" class="swap-on" />
-                        <x-mary-icon x-ref="moon" name="o-moon" class="swap-off"  />
+                        <input id="{{ $uuid }}" type="checkbox" class="{{ Mary::classes('opacity-0') }}" @click="toggle()" :value="theme" />
+                        <x-mary-icon x-ref="sun" name="o-sun" class="{{ Mary::classes('swap-on') }}" />
+                        <x-mary-icon x-ref="moon" name="o-moon" class="{{ Mary::classes('swap-off') }}"  />
                     </label>
                 </div>
                 <script>

--- a/src/View/Components/TimelineItem.php
+++ b/src/View/Components/TimelineItem.php
@@ -20,13 +20,13 @@ class TimelineItem extends Component
         public ?bool $first = false,
         public ?bool $last = false,
 
-        public? string $connectorPendingClass = "border-s-base-300",
-        public? string $connectorActiveClass = "!border-s-primary",
-        public? string $bulletActiveClass = "!bg-primary",
-        public? string $bulletPendingClass = "bg-base-300",
+        public ?string $connectorPendingClass = null,
+        public ?string $connectorActiveClass = null,
+        public ?string $bulletActiveClass = null,
+        public ?string $bulletPendingClass = null,
 
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function render(): View|Closure|string
@@ -34,43 +34,50 @@ class TimelineItem extends Component
         return <<<'HTML'
                 <div>
                     <!-- Last item `border cut` -->
-                    <div @class(["border-s-2 $connectorPendingClass h-5 -mb-5" => $last, $connectorActiveClass => !$pending])>
+                    <div class="{{ Mary::classes([
+                            'border-s-2 h-5 -mb-5' => $last,
+                            'border-s-base-300' => $last && is_null($connectorPendingClass),
+                            '!border-s-primary' => ! $pending && is_null($connectorActiveClass),
+                        ])->addRaw($last ? $connectorPendingClass : null)
+                          ->addRaw(! $pending ? $connectorActiveClass : null) }}">
                     </div>
 
                     <!-- WRAPPER THAT ALSO ACTS A LINE CONNECTOR -->
-                    <div @class([
-                            "border-s-2 $connectorPendingClass ps-8 py-3",
-                            $connectorActiveClass => !$pending,
-                            "pt-0" => $first,
-                            "!border-s-0" => $last,
-                         ])
-                    >
+                    <div class="{{ Mary::classes([
+                            'border-s-2 ps-8 py-3',
+                            'border-s-base-300' => is_null($connectorPendingClass),
+                            '!border-s-primary' => ! $pending && is_null($connectorActiveClass),
+                            'pt-0' => $first,
+                            '!border-s-0' => $last,
+                        ])->addRaw($connectorPendingClass)
+                          ->addRaw(! $pending ? $connectorActiveClass : null) }}">
                         <!-- BULLET -->
-                        <div @class([
-                                "w-4 h-4 -mb-5 -ms-[41px] $bulletPendingClass rounded-full",
-                                $bulletActiveClass => !$pending,
-                                "!-ms-[39px]" => $last,
-                                "w-8 h-8 !-ms-[48px] -mb-7" => $icon,
-                                "-ms-[46px]!" => $last && $icon,
-                             ])
-                        >
+                        <div class="{{ Mary::classes([
+                                'w-4 h-4 -mb-5 -ms-[41px] rounded-full',
+                                'bg-base-300' => is_null($bulletPendingClass),
+                                '!bg-primary' => ! $pending && is_null($bulletActiveClass),
+                                '!-ms-[39px]' => $last,
+                                'w-8 h-8 !-ms-[48px] -mb-7' => $icon,
+                                '-ms-[46px]!' => $last && $icon,
+                            ])->addRaw($bulletPendingClass)
+                              ->addRaw(! $pending ? $bulletActiveClass : null) }}">
                             <!-- ICON -->
                             @if($icon)
-                                <x-mary-icon :name="$icon" @class(["ms-2 mt-1 w-4 h-4", "text-base-100" => !$pending ])  />
+                                <x-mary-icon :name="$icon" class="{{ Mary::classes(['ms-2 mt-1 w-4 h-4', 'text-base-100' => ! $pending]) }}" />
                             @endif
                         </div>
 
                         <!-- TITLE -->
-                        <div @class(["font-bold mb-1"])>{{ $title }}</div>
+                        <div @maryClass(["font-bold mb-1"])>{{ $title }}</div>
 
                         <!-- SUBTITLE -->
                         @if($subtitle)
-                            <div class="text-xs text-base-content/30 font-bold">{{ $subtitle }}</div>
+                            <div class="{{ Mary::classes('text-xs text-base-content/30 font-bold') }}">{{ $subtitle }}</div>
                         @endif
 
                         <!-- DESCRIPTION -->
                         @if($description)
-                            <div class="text-sm mt-3">
+                            <div class="{{ Mary::classes('text-sm mt-3') }}">
                                 {{ $description }}
                             </div>
                         @endif

--- a/src/View/Components/Toast.php
+++ b/src/View/Components/Toast.php
@@ -9,9 +9,8 @@ use Illuminate\View\Component;
 class Toast extends Component
 {
     public function __construct(
-        public string $position = 'toast-top toast-end',
-    ) {
-    }
+        public ?string $position = null,
+    ) {}
 
     public function render(): View|Closure|string
     {
@@ -114,24 +113,24 @@ class Toast extends Component
                     @mary-toast.window="start($event.detail.toast)"
                 >
                     <div
-                        class="toast !whitespace-normal rounded-box fixed cursor-pointer z-[999] overflow-hidden"
-                        :class="toast.position || '{{ $position }}'"
+                        class="{{ Mary::classes('toast !whitespace-normal rounded-box fixed cursor-pointer z-[999] overflow-hidden') }}"
+                        :class="toast.position || '{{ is_null($position) ? Mary::classes('toast-top toast-end') : Mary::classes()->addRaw($position) }}'"
                         x-show="show"
                         @mouseenter="pause()"
                         @mouseleave="resume()"
-                        x-classes="alert alert-success alert-warning alert-error alert-info top-10 end-10 toast toast-top toast-bottom toast-center toast-end toast-middle toast-start"
+                        x-classes="{{ Mary::classes('alert alert-success alert-warning alert-error alert-info top-10 end-10 toast toast-top toast-bottom toast-center toast-end toast-middle toast-start') }}"
                         @click="show = false; clearInterval(interval)"
                     >
-                        <div class="alert gap-2" :class="toast.css">
-                            <div x-html="toast.icon" class="hidden sm:inline-block"></div>
-                            <div class="grid">
-                                <div x-html="toast.title" class="font-bold"></div>
-                                <div x-html="toast.description" class="text-xs"></div>
+                        <div class="{{ Mary::classes('alert gap-2') }}" :class="toast.css">
+                            <div x-html="toast.icon" class="{{ Mary::classes('hidden sm:inline-block') }}"></div>
+                            <div class="{{ Mary::classes('grid') }}">
+                                <div x-html="toast.title" class="{{ Mary::classes('font-bold') }}"></div>
+                                <div x-html="toast.description" class="{{ Mary::classes('text-xs') }}"></div>
                             </div>
                         </div>
                         <progress
                             x-show="!toast.noProgress"
-                            class="-mt-3 h-1 w-full progress"
+                            class="{{ Mary::classes('-mt-3 h-1 w-full progress') }}"
                             :class="toast.progressClass"
                             :max="maxProgress"
                             :value="progress">

--- a/src/View/Components/Toggle.php
+++ b/src/View/Components/Toggle.php
@@ -15,15 +15,15 @@ class Toggle extends Component
         public ?string $label = null,
         public ?bool $right = false,
         public ?string $hint = null,
-        public ?string $hintClass = 'fieldset-label',
+        public ?string $hintClass = null,
 
         // Validations
         public ?string $errorField = null,
-        public ?string $errorClass = 'text-error',
+        public ?string $errorClass = null,
         public ?bool $omitError = false,
         public ?bool $firstErrorOnly = false,
     ) {
-        $this->uuid = "mary" . md5(serialize($this)) . $id;
+        $this->uuid = 'mary' . md5(serialize($this)) . $id;
     }
 
     public function modelName(): ?string
@@ -40,9 +40,9 @@ class Toggle extends Component
     {
         return <<<'BLADE'
             <div>
-                <fieldset class="fieldset">
-                    <div class="w-full">
-                        <label @class(["flex gap-3 items-center cursor-pointer", "justify-between" => $right, "!items-start" => $hint])>
+                <fieldset class="{{ Mary::classes('fieldset') }}">
+                    <div class="{{ Mary::classes('w-full') }}">
+                        <label @maryClass(["flex gap-3 items-center cursor-pointer", "justify-between" => $right, "!items-start" => $hint])>
 
                             {{-- TOGGLE --}}
                             <input
@@ -51,24 +51,24 @@ class Toggle extends Component
 
                                 {{
                                     $attributes->whereDoesntStartWith('id')
-                                        ->class(["order-2" => $right])
-                                        ->merge(['class' => 'toggle'])
+                                        ->maryClass(["order-2" => $right])
+                                        ->class(Mary::classes('toggle'))
                                 }}
                             />
 
                             {{-- LABEL --}}
-                             <div @class(["order-1" => $right])>
-                                <div class="text-sm font-medium">
+                             <div @maryClass(["order-1" => $right])>
+                                <div class="{{ Mary::classes('text-sm font-medium') }}">
                                     {{ $label }}
 
                                     @if($attributes->get('required'))
-                                        <span class="text-error">*</span>
+                                        <span class="{{ Mary::classes('text-error') }}">*</span>
                                     @endif
                                 </div>
 
                                 {{-- HINT --}}
                                 @if($hint)
-                                    <div class="{{ $hintClass }}" x-classes="fieldset-label">{{ $hint }}</div>
+                                    <div class="{{ is_null($hintClass) ? Mary::classes('fieldset-label') : Mary::classes()->addRaw($hintClass) }}" x-classes="{{ Mary::classes('fieldset-label') }}">{{ $hint }}</div>
                                 @endif
                             </div>
                         </label>
@@ -78,7 +78,7 @@ class Toggle extends Component
                     @if(!$omitError && $errors->has($errorFieldName()))
                         @foreach($errors->get($errorFieldName()) as $message)
                             @foreach(Arr::wrap($message) as $line)
-                                <div class="{{ $errorClass }}" x-class="text-error">{{ $line }}</div>
+                                <div class="{{ is_null($errorClass) ? Mary::classes('text-error') : Mary::classes()->addRaw($errorClass) }}" x-class="{{ Mary::classes('text-error') }}">{{ $line }}</div>
                                 @break($firstErrorOnly)
                             @endforeach
                             @break($firstErrorOnly)


### PR DESCRIPTION
## Context

My current project has CSS class-name collisions between Tailwind utilities and existing styles. The only reliable way to isolate Tailwind’s generated CSS is to configure a prefix.

However, maryUI currently outputs its internal Tailwind and DaisyUI classes without a prefix. This creates an incompatibility:

- Using Tailwind without a prefix causes CSS collisions in the application.
- Enabling a Tailwind prefix prevents maryUI’s unprefixed classes from being generated and applied correctly.

Because maryUI uses internal utility classes throughout its entire component library, this issue cannot be solved at the application level or by overriding a few individual components.

Without native prefix support, using maryUI in my current project becomes unviable.

## Solution

This PR adds optional Tailwind CSS prefix support throughout maryUI.

The prefix can be configured in `config/mary.php`:

```php
'tailwind_prefix' => 'tw',
```

This must match the Tailwind configuration:

```css
@import "tailwindcss" prefix(tw);
```

maryUI then transforms its internal classes automatically:

```text
btn bg-primary flex
```

Into:

```text
tw:btn tw:bg-primary tw:flex
```

Prefix separators are normalized consistently:

```php
'tailwind_prefix' => 'tw';  // tw:btn
'tailwind_prefix' => 'tw:'; // tw:btn
'tailwind_prefix' => 'tw-'; // tw-btn
```

When no separator is provided, maryUI uses `:` by default. Explicit `:` and `-` separators are preserved.

## Static Tailwind Source Generation

Because prefixes are applied at runtime, Tailwind cannot discover the resulting class names directly from maryUI’s source files.

This PR provides a command that generates a static HTML source containing all required class candidates with the configured prefix already applied:

```shell
php artisan mary:build-class-source
```

The generated file can then be included as a Tailwind source:

```css
@source "../../storage/framework/mary/classes.html";
```

Its destination can be configured through:

```php
'class_source_path' => storage_path('framework/mary/classes.html'),
```

It can also be overridden for an individual build:

```shell
php artisan mary:build-class-source \
    --path=resources/css/generated/mary-classes.html
```

## Source-Based Class Extraction

The generated Tailwind source was previously built from an internal static class catalog maintained by maryUI. That catalog was an internal implementation detail and was never exposed to library users.

This PR replaces that internal implementation with source-based extraction. The generator now discovers class candidates directly from maryUI components, keeping the generated Tailwind source aligned with the actual component code.

This change is transparent to existing users and does not introduce any additional maintenance requirements.

The extractor recognizes candidates passed through maryUI’s prefix-aware class APIs:

- `Mary::classes(...)`
- `app('mary')->classes(...)`
- `@maryClass(...)`
- `$attributes->maryClass(...)`
- `add(...)` calls chained from these APIs

For example:

```php
Mary::classes('btn flex')
    ->add([
        'opacity-50' => $disabled,
        'hidden' => false,
    ])
    ->addRaw($customClass);
```

The extractor includes the statically declared candidates:

```text
btn
flex
hidden
opacity-50
```

The runtime value of `$customClass` is intentionally excluded because `addRaw()` represents application-provided classes that must remain untouched.

The extractor also distinguishes maryUI’s class builder from unrelated APIs. A standalone `add()` call from another object is not interpreted as a CSS class source.

## Conditional and Dynamic Classes

Conditional class arrays are handled by extracting their class keys without treating condition expressions as class candidates:

```php
[
    'opacity-50' => $disabled,
    'hidden' => session('condition'),
]
```

Only `opacity-50` and `hidden` are extracted.

The extractor also resolves dynamic class fragments when their possible values are declared in the same source file. This includes values found in:

- Property and variable assignments
- Conditional assignments
- Method return values
- `match` branches
- Interpolated method calls

This supports existing maryUI patterns such as dynamically selected tooltip positions without requiring components to duplicate every possible class manually.

If a dynamic class cannot be resolved safely, generation fails with a clear error instead of silently producing an incomplete Tailwind source.

After extraction, candidates are split, deduplicated, sorted, passed through the same `ClassBuilder` used at runtime, and written to the generated HTML source.

## Blade and Livewire SFC Sources

In addition to maryUI’s internal component sources, the extractor supports application Blade views and Livewire single-file components.

Application sources are read from `resources/views` by default:

```php
'class_source_paths' => [
    resource_path('views'),
],
```

Additional source directories can be configured when necessary:

```php
'class_source_paths' => [
    resource_path('views'),
    resource_path('livewire'),
],
```

Other packages can register their own Blade or Livewire SFC directories without replacing maryUI’s internal sources or the application’s configured paths:

```php
use Mary\Facades\Mary;

public function boot(): void
{
    Mary::addClassSourcePath(__DIR__.'/../resources/views');
}
```

This prevents the extractor from being coupled exclusively to maryUI’s own source tree and allows other packages using the same class-building APIs to participate in source generation.

## Main Changes

- Adds the `mary.tailwind_prefix` configuration.
- Applies the configured prefix to maryUI’s internal Tailwind and DaisyUI classes.
- Uses `:` when the configured prefix does not include a separator.
- Preserves explicit `:` and `-` separators.
- Prevents classes from being prefixed more than once.
- Keeps raw and application-provided customization classes unchanged.
- Adds a command for generating a static Tailwind source.
- Replaces maryUI’s internal static class catalog with source-based extraction.
- Extracts candidates from maryUI’s class-building APIs.
- Supports conditional and statically resolvable dynamic classes.
- Supports Blade views and Livewire SFC directories.
- Allows applications and external packages to register additional source paths.
- Ignores unrelated `add()` calls and values passed through `addRaw()`.

## Backward Compatibility

Prefix support is completely optional.

When `tailwind_prefix` is not configured, maryUI continues generating the same unprefixed classes as before.

Existing projects do not need to:

- Change their configuration
- Regenerate a class source
- Update their Tailwind setup
- Modify existing maryUI components
- Maintain any additional class catalog

The source extractor is only required as part of the opt-in prefixed workflow. Projects that do not use a Tailwind prefix retain the current maryUI behavior without any action.