### PR TITLE
Table: add sortable (drag-and-drop sorting feature) and selectable-condition

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -25,9 +25,14 @@ class Table extends Component
         public ?bool $noHeaders = false,
         public ?bool $selectable = false,
         public ?string $selectableKey = 'id',
+        public mixed $selectableCondition = null,
         public ?bool $expandable = false,
         public ?string $expandableKey = 'id',
         public mixed $expandableCondition = null,
+        public ?bool $sortable = false,
+        public ?string $sortableKey = 'id',
+        public mixed $sortableCondition = null,
+        public mixed $sortableMethod = null,
         public ?string $link = null,
         public ?bool $withPagination = false,
         public ?string $perPage = null,
@@ -295,7 +300,11 @@ class Table extends Component
                                 <!-- EXPAND EXTRA HEADER -->
                                 @if($expandable)
                                     <th class="w-1"></th>
-                                 @endif
+                                @endif
+
+                                @if($sortable)
+                                    <th class="w-1"></th>
+                                @endif
 
                                 @foreach($headers as $header)
                                      @php
@@ -330,7 +339,11 @@ class Table extends Component
                         </thead>
 
                         <!-- ROWS -->
-                        <tbody>
+                        <tbody 
+                            @if($sortable)
+                                wire:sort="{{ $sortableMethod }}"
+                            @endif
+                        >
                             @foreach($rows as $k => $row)
                                 <tr
                                     wire:key="{{ $uuid }}-{{ $k }}"
@@ -342,13 +355,15 @@ class Table extends Component
                                     <!-- CHECKBOX -->
                                     @if($selectable)
                                         <td class="w-1">
-                                            <input
-                                                id="checkbox-{{ $uuid }}-{{ $k }}"
-                                                type="checkbox"
-                                                class="checkbox checkbox-sm"
-                                                value="{{ data_get($row, $selectableKey) }}"
-                                                x-model{{ $selectableModifier() }}="selection"
-                                                @click.stop="toggleCheck($el.checked, {{ json_encode($row) }})" />
+                                            @if(data_get($row, $selectableCondition))
+                                                <input
+                                                    id="checkbox-{{ $uuid }}-{{ $k }}"
+                                                    type="checkbox"
+                                                    class="checkbox checkbox-sm"
+                                                    value="{{ data_get($row, $selectableKey) }}"
+                                                    x-model{{ $selectableModifier() }}="selection"
+                                                    @click.stop="toggleCheck($el.checked, {{ json_encode($row) }})" />
+                                            @endif
                                         </td>
                                     @endif
 
@@ -363,7 +378,19 @@ class Table extends Component
                                                     @click="toggleExpand({{ $getKeyValue($row, 'expandableKey') }});" />
                                             @endif
                                         </td>
-                                     @endif
+                                    @endif
+
+                                    <!-- SORT ICON -->
+                                    @if($sortable)
+                                        <td class="w-1 pe-0 py-0">
+                                            @if(data_get($row, $sortableCondition))
+                                                <x-mary-icon
+                                                    wire:sort:item="{{ $row->id }}"
+                                                    name="o-bars-3"
+                                                    class="cursor-grab active:cursor-grabbing p-2 w-8 h-8 bg-base-300 rounded-lg" />
+                                            @endif
+                                        </td>
+                                    @endif
 
                                     <!--  ROW VALUES -->
                                     @foreach($headers as $header)

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -385,7 +385,7 @@ class Table extends Component
                                         <td class="w-1 pe-0 py-0">
                                             @if(data_get($row, $sortableCondition))
                                                 <x-mary-icon
-                                                    wire:sort:item="{{ $row->id }}"
+                                                    wire:sort:item="{{ data_get($row, $sortableKey) }}"
                                                     name="o-bars-3"
                                                     class="cursor-grab active:cursor-grabbing p-2 w-8 h-8 bg-base-300 rounded-lg" />
                                             @endif


### PR DESCRIPTION
**Sortable (drag-and-drop feature):**

Add sortable feature to sort rows by drag-and-drop using Livewire's [wire:sort](https://livewire.laravel.com/docs/4.x/wire-sort). See instructions for documentation below:

**Row drag-and-drop sorting**

Use `sortable` attribute in conjunction with `sortable-method="handleSort"` to sort rows by dragging and dropping them in place. The `sortable-method` is where you provide relevant logic to persist to the database. 

```blade
<x-table ... sortable sortable-method="handleSort">
```
```php
public TodoTable $table;

public function handleSort($id, $position)
{
	$task = $this->table->tasks()->findOrFail($id);

	// Update the task's position and re-order other tasks...
}
```
[Screencast from 2026-08-21 11-22-56.webm](https://github.com/user-attachments/assets/b6ca1683-874e-4347-af80-60ba34c91020)


By default, it will look up for `$row->id` attribute. You can customize this with `sortable-key` attribute.

```blade
{{-- Uses `$row->mycode` as sortable key --}}
<x-table ... sortable sortable-key="mycode" />
```

You can also control the sort icon visibility by using `sortable-condition` attribute.

```blade
{{-- It will check each row for the `is_admin` field --}}
<x-table ... sortable sortable-condition="is_admin" />
```

----------------------------------------------------------------------------------------------------------------------------

**Selectable condition:**

Add condition to `selectable` feature. See instructions for documentation below:

You can also control the select icon visibility by using `selectable-condition` attribute.

```blade
{{-- It will check each row for the `is_admin` field --}}
<x-table ... selectable selectable-condition="is_admin" />
```